### PR TITLE
Policy statements ignore sorting

### DIFF
--- a/provider/rustfs_policy_ressource.go
+++ b/provider/rustfs_policy_ressource.go
@@ -66,11 +66,11 @@ func (r *PolicyRessource) Schema(_ context.Context, _ resource.SchemaRequest, re
 						"effect": schema.StringAttribute{
 							Required: true,
 						},
-						"action": schema.ListAttribute{
+						"action": schema.SetAttribute{
 							ElementType: types.StringType,
 							Required:    true,
 						},
-						"ressource": schema.ListAttribute{
+						"ressource": schema.SetAttribute{
 							ElementType: types.StringType,
 							Required:    true,
 						},


### PR DESCRIPTION
The nested attributes `action` and `ressource` of policy statements are sometimes returned in a different order by the rustfs api. This leads to terraform detecting changes where there are none, when a previously applied policy is returned in a different order on read. `action` and `ressource` being Sets instead of Lists solves this issue as referenced here:

https://github.com/hashicorp/terraform-plugin-framework/issues/305#issuecomment-1256319576

closes #15 