### PR TITLE
Fix policy read and force user replacement on policy change

### DIFF
--- a/main.go
+++ b/main.go
@@ -31,7 +31,7 @@ func main() {
 		// TODO: Update this string with the published name of your provider.
 		// Also update the tfplugindocs generate command to either remove the
 		// -provider-name flag or set its value to the updated provider name.
-		Address: "registry.terraform.io/weinmann/rustfs",
+		Address: "registry.terraform.io/weinmann-emt/rustfs",
 		Debug:   debug,
 	}
 

--- a/pkg/rustfs/policy.go
+++ b/pkg/rustfs/policy.go
@@ -35,8 +35,8 @@ type statementReplySingle struct {
 }
 
 type policyReply struct {
-	PolicyName string `json:"policy_name"`
-	Policy     string `json:"policy"`
+	PolicyName string          `json:"policy_name"`
+	Policy     json.RawMessage `json:"policy"`
 }
 
 func (c *RustfsAdmin) CreatePolicy(policy Policy) error {
@@ -89,13 +89,25 @@ func (c *RustfsAdmin) ReadPolicy(policy string) (Policy, error) {
 	}
 	read.Name = instance.PolicyName
 	read.Version = "2012-10-17"
-	err = json.NewDecoder(strings.NewReader(instance.Policy)).Decode(&statement)
+
+	// The rustfs API may return `policy` either as a JSON string containing
+	// the policy document, or as an inline JSON object. Normalize to bytes.
+	policyBytes := []byte(instance.Policy)
+	if len(policyBytes) > 0 && policyBytes[0] == '"' {
+		var asString string
+		if err := json.Unmarshal(policyBytes, &asString); err != nil {
+			return Policy{}, err
+		}
+		policyBytes = []byte(asString)
+	}
+
+	err = json.NewDecoder(strings.NewReader(string(policyBytes))).Decode(&statement)
 	// We have no error!
 	if err == nil {
 		read.Statement = statement.Statement
 		return read, nil
 	}
-	err_single := json.NewDecoder(strings.NewReader(instance.Policy)).Decode(&statement_single)
+	err_single := json.NewDecoder(strings.NewReader(string(policyBytes))).Decode(&statement_single)
 	if err_single == nil {
 		statements := []PolicyStatement{}
 		for _, got := range statement_single.Statement {

--- a/provider/rustfs_policy_ressource.go
+++ b/provider/rustfs_policy_ressource.go
@@ -194,6 +194,30 @@ func (r *PolicyRessource) Update(ctx context.Context, req resource.UpdateRequest
 		return
 	}
 
+	statements := []rustfs.PolicyStatement{}
+	for _, i := range plan.Statement {
+		statements = append(statements,
+			rustfs.PolicyStatement{
+				Effect:   i.Effect,
+				Action:   i.Action,
+				Resource: i.Ressource,
+			},
+		)
+	}
+	policy := rustfs.Policy{
+		Version:   plan.Version.ValueString(),
+		Name:      plan.Name.ValueString(),
+		Statement: statements,
+	}
+	err := r.client.RustClient.CreatePolicy(policy)
+	if err != nil {
+		resp.Diagnostics.AddError(
+			"Error updating policy",
+			"Could not update policy, unexpected error: "+err.Error(),
+		)
+		return
+	}
+
 	diags = resp.State.Set(ctx, plan)
 	resp.Diagnostics.Append(diags...)
 	if resp.Diagnostics.HasError() {
@@ -214,6 +238,10 @@ func (r *PolicyRessource) Delete(ctx context.Context, req resource.DeleteRequest
 
 	err := r.client.RustClient.DeletePolicy(data.Name.ValueString())
 	if err != nil {
-		tflog.Error(ctx, err.Error())
+		resp.Diagnostics.AddError(
+			"Error deleting policy",
+			"Could not delete policy, unexpected error: "+err.Error(),
+		)
+		return
 	}
 }

--- a/provider/rustfs_user_resource.go
+++ b/provider/rustfs_user_resource.go
@@ -7,7 +7,9 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringdefault"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-plugin-log/tflog"
 	"github.com/weinmann-emt/terraform-provider-rustfs/pkg/rustfs"
@@ -59,7 +61,10 @@ func (r *RustfsUserRessource) Schema(ctx context.Context, req resource.SchemaReq
 			},
 			"policy": schema.StringAttribute{
 				Required:            true,
-				MarkdownDescription: "User policy",
+				MarkdownDescription: "User policy. Changing this forces a new user to be created (the underlying API does not support updating a user's policy in-place).",
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.RequiresReplace(),
+				},
 			},
 		},
 	}
@@ -154,12 +159,26 @@ func (r *RustfsUserRessource) Update(ctx context.Context, req resource.UpdateReq
 		return
 	}
 
+	account := rustfs.UserAccount{
+		AccessKey: plan.AccessKey.ValueString(),
+		SecretKey: plan.SecretKey.ValueString(),
+		Policy:    plan.Policy.ValueString(),
+	}
+
+	err := r.client.RustClient.UpdateUserAccount(account)
+	if err != nil {
+		resp.Diagnostics.AddError(
+			"Error updating user",
+			"Could not update user, unexpected error: "+err.Error(),
+		)
+		return
+	}
+
 	diags = resp.State.Set(ctx, plan)
 	resp.Diagnostics.Append(diags...)
 	if resp.Diagnostics.HasError() {
 		return
 	}
-	// plan.LastUpdated = types.StringValue(time.Now().Format(time.RFC850))
 }
 
 func (r *RustfsUserRessource) Delete(ctx context.Context, req resource.DeleteRequest, resp *resource.DeleteResponse) {
@@ -176,7 +195,11 @@ func (r *RustfsUserRessource) Delete(ctx context.Context, req resource.DeleteReq
 	}
 	err := r.client.RustClient.DeleteUserAccount(account)
 	if err != nil {
-		tflog.Error(ctx, err.Error())
+		resp.Diagnostics.AddError(
+			"Error deleting user",
+			"Could not delete user, unexpected error: "+err.Error(),
+		)
+		return
 	}
 }
 


### PR DESCRIPTION
Disclaimer: These changes were made with claude. If you're unhappy with LLM generated/changed code thats totally understandable. In this case feel free to just ignore/close the PR.


## Summary

- **`pkg/rustfs/policy`**: `ReadPolicy` now accepts both legacy string and new inline-object shapes for the `policy` field returned by `info-canned-policy`. Recent rustfs versions return the policy document as an inline JSON object instead of a JSON-encoded string, which caused `json: cannot unmarshal object into Go struct field policyReply.policy of type string`.
- **`provider/rustfs_policy_ressource`**: `Update` now actually pushes the planned policy document (previously it was a no-op that only wrote state). `Delete` now surfaces errors as diagnostics instead of only logging them.
- **`provider/rustfs_user_resource`**: `policy` is marked `RequiresReplace`. The rustfs API returns `NotImplemented` for in-place policy changes on a user, so the only way to apply a new policy is to recreate the user.
- **`main`**: provider Address corrected to `registry.terraform.io/weinmann-emt/rustfs` to match the published source.

## Test plan

- [x] `go build ./...`
- [x] Verified against a live rustfs instance: previously failing `tofu plan` (policy read error) now succeeds.
- [x] Changing `policy` on a `rustfs_user` plans as destroy + recreate; `access_key`/`secret_key` are reused when sourced from stable inputs (e.g. `random_password`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)