### PR TITLE
fix: remove duplicate doRequest calls in quota operations (#27)

### DIFF
--- a/pkg/rustfs/admin_client.go
+++ b/pkg/rustfs/admin_client.go
@@ -128,8 +128,8 @@ func (c *RustfsAdmin) createRequest(ctx context.Context, request RequestData) (*
 	return req, nil
 }
 
-func (c *RustfsAdmin) DoDirectRequest (ctx context.Context,  request RequestData)(res *http.Response, err error){
-	urlStr := strings.Replace(c.endpointURL, "/rustfs/admin/"+ rustfsApiVersion, "", 1) + "/" + request.RelPath
+func (c *RustfsAdmin) DoDirectRequest(ctx context.Context, request RequestData) (res *http.Response, err error) {
+	urlStr := strings.Replace(c.endpointURL, "/rustfs/admin/"+rustfsApiVersion, "", 1) + "/" + request.RelPath
 	// If there are any query values, add them to the end.
 	if len(request.QueryValues) > 0 {
 		urlStr = urlStr + "?" + s3utils.QueryEncode(request.QueryValues)

--- a/pkg/rustfs/bucket.go
+++ b/pkg/rustfs/bucket.go
@@ -9,12 +9,11 @@ type Bucket struct {
 	Name string
 }
 
-
-func (c *RustfsAdmin) CreateBucket(bucket string)(err error){
+func (c *RustfsAdmin) CreateBucket(bucket string) (err error) {
 	bucket = strings.ToLower(bucket)
 	req_data := RequestData{
-		Method:      "PUT",
-		RelPath:     bucket,
+		Method:  "PUT",
+		RelPath: bucket,
 	}
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
@@ -25,11 +24,11 @@ func (c *RustfsAdmin) CreateBucket(bucket string)(err error){
 	return nil
 }
 
-func (c *RustfsAdmin) DeleteBucket(bucket string)(err error){
+func (c *RustfsAdmin) DeleteBucket(bucket string) (err error) {
 	bucket = strings.ToLower(bucket)
 	req_data := RequestData{
-		Method:      "DELETE",
-		RelPath:     bucket,
+		Method:  "DELETE",
+		RelPath: bucket,
 	}
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()

--- a/pkg/rustfs/quota.go
+++ b/pkg/rustfs/quota.go
@@ -6,16 +6,15 @@ import (
 )
 
 type Quota struct {
-	Bucket string `json:"bucket"`
-	Quota int `json:"quota"` //Size of the thing
+	Bucket     string `json:"bucket"`
+	Quota      int    `json:"quota"` //Size of the thing
 	Quota_Type string `json:"quota_type"`
 }
 
-func (c *RustfsAdmin) ReadQuota(bucket string)(quota Quota, err error){
+func (c *RustfsAdmin) ReadQuota(bucket string) (quota Quota, err error) {
 	req_data := RequestData{
-		Method:      "GET",
-		RelPath:     "quota/"+bucket,
-
+		Method:  "GET",
+		RelPath: "quota/" + bucket,
 	}
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
@@ -27,16 +26,16 @@ func (c *RustfsAdmin) ReadQuota(bucket string)(quota Quota, err error){
 	return quota, nil
 }
 
-func (c *RustfsAdmin) SetQuota(new Quota)(quota Quota, err error){
+func (c *RustfsAdmin) SetQuota(new Quota) (quota Quota, err error) {
 	new.Quota_Type = "HARD"
 	bytes, err := json.Marshal(new)
 	if err != nil {
 		return Quota{}, err
 	}
 	req_data := RequestData{
-		Method:      "PUT",
-		RelPath:     "quota/"+new.Bucket,
-		Content:     bytes,
+		Method:  "PUT",
+		RelPath: "quota/" + new.Bucket,
+		Content: bytes,
 	}
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
@@ -54,8 +53,8 @@ func (c *RustfsAdmin) SetQuota(new Quota)(quota Quota, err error){
 
 func (c *RustfsAdmin) DeletQuota(bucket string) (err error) {
 	req_data := RequestData{
-		Method:      "DELETE",
-		RelPath:     "quota/"+bucket,
+		Method:  "DELETE",
+		RelPath: "quota/" + bucket,
 	}
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
@@ -66,4 +65,3 @@ func (c *RustfsAdmin) DeletQuota(bucket string) (err error) {
 	defer resp.Body.Close()
 	return nil
 }
-

--- a/pkg/rustfs/quota.go
+++ b/pkg/rustfs/quota.go
@@ -40,11 +40,11 @@ func (c *RustfsAdmin) SetQuota(new Quota)(quota Quota, err error){
 	}
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
-	c.doRequest(ctx, req_data)
 	resp, err := c.doRequest(ctx, req_data)
 	if err != nil {
 		return Quota{}, err
 	}
+	defer resp.Body.Close()
 	err = json.NewDecoder(resp.Body).Decode(&quota)
 	if err != nil {
 		return Quota{}, err
@@ -52,22 +52,18 @@ func (c *RustfsAdmin) SetQuota(new Quota)(quota Quota, err error){
 	return quota, nil
 }
 
-func (c *RustfsAdmin) DeletQuota(bucket string)(err error){
-
-	if err != nil {
-		return err
-	}
+func (c *RustfsAdmin) DeletQuota(bucket string) (err error) {
 	req_data := RequestData{
 		Method:      "DELETE",
 		RelPath:     "quota/"+bucket,
 	}
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
-	c.doRequest(ctx, req_data)
-	_, err = c.doRequest(ctx, req_data)
+	resp, err := c.doRequest(ctx, req_data)
 	if err != nil {
 		return err
 	}
+	defer resp.Body.Close()
 	return nil
 }
 

--- a/pkg/rustfs/quota_test.go
+++ b/pkg/rustfs/quota_test.go
@@ -8,9 +8,8 @@ import (
 	"github.com/weinmann-emt/terraform-provider-rustfs/pkg/rustfs"
 )
 
-
 func TestReadQuota(t *testing.T) {
-	name :=  randomString(8)
+	name := randomString(8)
 	dut := getClient()
 	name = strings.ToLower(name)
 	dut.CreateBucket(name)
@@ -24,12 +23,12 @@ func TestReadQuota(t *testing.T) {
 	dut.DeleteBucket(name)
 }
 
-func TestCRDQuota(t *testing.T){
-	name :=  randomString(8)
+func TestCRDQuota(t *testing.T) {
+	name := randomString(8)
 	name = strings.ToLower(name)
 	quota := rustfs.Quota{
 		Bucket: name,
-		Quota: 100054541,
+		Quota:  100054541,
 	}
 	dut := getClient()
 	dut.CreateBucket(name)
@@ -51,6 +50,5 @@ func TestCRDQuota(t *testing.T){
 	if err != nil {
 		t.Error("error during quota remove")
 	}
-
 
 }

--- a/provider/rustfs_quota_ressource_test.go
+++ b/provider/rustfs_quota_ressource_test.go
@@ -23,7 +23,7 @@ resource "rustfs_quota" "test" {
 }
 `, Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttr("rustfs_bucket.test2", "name", "somebucket2"),
-					resource.TestCheckResourceAttr("rustfs_quota.test", "quota","100000"),
+					resource.TestCheckResourceAttr("rustfs_quota.test", "quota", "100000"),
 				)},
 		}})
 }


### PR DESCRIPTION
Fixes #27

## Problem

`SetQuota` and `DeletQuota` in `pkg/rustfs/quota.go` call `c.doRequest()` twice per operation. The first call's result and error are silently discarded. In `DeletQuota`, there's also dead code checking `if err != nil` where `err` is always the named return value (nil at that point).

This means every quota create/update/delete hits the RustFS admin API twice, and errors from the first call are silently ignored.

## Fix

- `SetQuota`: removed first `doRequest` call, kept single call with proper error handling and response body close
- `DeletQuota`: removed dead `if err != nil` check, removed first `doRequest` call, kept single call with proper error handling and response body close