### PR TITLE
fix: TLS nil pointer check, typo, consistent region, remove dead code (#37)

### DIFF
--- a/provider/provider.go
+++ b/provider/provider.go
@@ -82,33 +82,28 @@ func (p *RustfsProvider) Configure(ctx context.Context, req provider.ConfigureRe
 
 	generatedConfig := generateRustClientConfig(config)
 
-	// Example client configuration for data sources and resources
 	tr, err := minio.DefaultTransport(config.Ssl.ValueBool())
-	if config.Insecure.ValueBool() {
-		tr.TLSClientConfig.InsecureSkipVerify = true
-	}
 	if err != nil {
 		resp.Diagnostics.AddError(err.Error(), err.Error())
 		return
 	}
-	minico_client, err := minio.New(config.Endpoint.ValueString(), &minio.Options{
+	if config.Insecure.ValueBool() {
+		tr.TLSClientConfig.InsecureSkipVerify = true
+	}
+	minio_client, err := minio.New(config.Endpoint.ValueString(), &minio.Options{
 		Secure:    config.Ssl.ValueBool(),
 		Creds:     credentials.NewStaticV4(config.AccessKey.ValueString(), config.AccessSecret.ValueString(), ""),
 		Transport: tr,
+		Region:    "us-east-1",
 	})
 	if err != nil {
 		resp.Diagnostics.AddError(err.Error(), err.Error())
 		return
 	}
 	client := &AllClient{
-		Minio:      minico_client,
+		Minio:      minio_client,
 		RustClient: rustfs.New(generatedConfig),
 	}
-
-	// if err != nil {
-	// 	resp.Diagnostics.AddError(err.Error(), err.Error())
-	// 	return
-	// }
 	resp.DataSourceData = client
 	resp.ResourceData = client
 }

--- a/provider/rustfs_bucket_ressource.go
+++ b/provider/rustfs_bucket_ressource.go
@@ -92,7 +92,7 @@ func (r *bucketRessource) Create(ctx context.Context, req resource.CreateRequest
 	}
 
 	err = r.client.Minio.MakeBucket(ctx, plan.Name.ValueString(), minio.MakeBucketOptions{
-		Region: "us-east-01",
+		Region: "us-east-1",
 	})
 	if err != nil {
 		resp.Diagnostics.AddError(


### PR DESCRIPTION
Fixes #37

## Fixes

### TLS nil pointer risk
Moved `err != nil` check for `DefaultTransport` BEFORE accessing `tr.TLSClientConfig`. Previously:`tr.TLSClientConfig.InsecureSkipVerify` was dereferenced before the error check, causing a nil pointer panic if transport creation failed.

### Variable typo
`minico_client` → `minio_client`

### Inconsistent region
Provider and bucket resource now both use `"us-east-1"` (the standard S3 region identifier) instead of mixing `"us-east-1"` and `"us-east-01"`.

### Dead code removed
Removed commented-out error handling block left over from earlier development.