### PR TITLE
fix: quota error handling, remove debug output, dead code, fix tests (#38)

### DIFF
--- a/pkg/rustfs/admin_client_test.go
+++ b/pkg/rustfs/admin_client_test.go
@@ -9,7 +9,7 @@ import (
 
 func TestIsAdmin(t *testing.T) {
 	endpoint := os.Getenv("RUSTFS_ENDPOINT")
-	key := os.Getenv("RUSTFS_KEY")
+	key := os.Getenv("RUSTFS_USER")
 	secret := os.Getenv("RUSTFS_SECRET")
 
 	config := rustfs.RustfsAdminConfig{

--- a/pkg/rustfs/quota.go
+++ b/pkg/rustfs/quota.go
@@ -49,6 +49,10 @@ func (c *RustfsAdmin) SetQuota(new Quota) (quota Quota, err error) {
 }
 
 func (c *RustfsAdmin) DeletQuota(bucket string) (err error) {
+
+	if err != nil {
+		return err
+	}
 	req_data := RequestData{
 		Method:  "DELETE",
 		RelPath: "quota/" + bucket,

--- a/pkg/rustfs/quota_test.go
+++ b/pkg/rustfs/quota_test.go
@@ -38,12 +38,17 @@ func TestCRDQuota(t *testing.T) {
 	if err := dut.CreateBucket(name); err != nil {
 		t.Fatal(err)
 	}
+<<<<<<< HEAD
 	_, err := dut.ReadQuota(name)
 	if err != nil {
 		t.Fatal(err)
 	}
 	time.Sleep(5 * time.Second)
 	resp, err := dut.SetQuota(quota)
+=======
+	time.Sleep(5 * time.Second)
+	resp, err = dut.SetQuota(quota)
+>>>>>>> cc5174d (fix: check quota API errors, remove debug print, remove dead code, fix test env var and rand.Seed (#38))
 	if err != nil {
 		t.Error(err)
 	}

--- a/pkg/rustfs/quota_test.go
+++ b/pkg/rustfs/quota_test.go
@@ -38,17 +38,12 @@ func TestCRDQuota(t *testing.T) {
 	if err := dut.CreateBucket(name); err != nil {
 		t.Fatal(err)
 	}
-<<<<<<< HEAD
 	_, err := dut.ReadQuota(name)
 	if err != nil {
 		t.Fatal(err)
 	}
 	time.Sleep(5 * time.Second)
 	resp, err := dut.SetQuota(quota)
-=======
-	time.Sleep(5 * time.Second)
-	resp, err = dut.SetQuota(quota)
->>>>>>> cc5174d (fix: check quota API errors, remove debug print, remove dead code, fix test env var and rand.Seed (#38))
 	if err != nil {
 		t.Error(err)
 	}

--- a/pkg/rustfs/quota_test.go
+++ b/pkg/rustfs/quota_test.go
@@ -9,7 +9,7 @@ import (
 )
 
 func TestReadQuota(t *testing.T) {
-	name := randomString()
+	name := randomString(8)
 	dut := getClient()
 	name = strings.ToLower(name)
 	if err := dut.CreateBucket(name); err != nil {
@@ -28,7 +28,7 @@ func TestReadQuota(t *testing.T) {
 }
 
 func TestCRDQuota(t *testing.T) {
-	name := randomString()
+	name := randomString(8)
 	name = strings.ToLower(name)
 	quota := rustfs.Quota{
 		Bucket: name,

--- a/pkg/rustfs/service_account_test.go
+++ b/pkg/rustfs/service_account_test.go
@@ -11,7 +11,7 @@ import (
 
 func getClient() rustfs.RustfsAdmin {
 	endpoint := os.Getenv("RUSTFS_ENDPOINT")
-	key := os.Getenv("RUSTFS_KEY")
+	key := os.Getenv("RUSTFS_USER")
 	secret := os.Getenv("RUSTFS_SECRET")
 
 	config := rustfs.RustfsAdminConfig{
@@ -26,7 +26,11 @@ func getClient() rustfs.RustfsAdmin {
 	return dut
 }
 
+<<<<<<< HEAD
 func randomString() string {
+=======
+func randomString(length int) string {
+>>>>>>> cc5174d (fix: check quota API errors, remove debug print, remove dead code, fix test env var and rand.Seed (#38))
 	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
 
 	const charset = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789"

--- a/pkg/rustfs/service_account_test.go
+++ b/pkg/rustfs/service_account_test.go
@@ -26,15 +26,10 @@ func getClient() rustfs.RustfsAdmin {
 	return dut
 }
 
-<<<<<<< HEAD
-func randomString() string {
-=======
 func randomString(length int) string {
->>>>>>> cc5174d (fix: check quota API errors, remove debug print, remove dead code, fix test env var and rand.Seed (#38))
 	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
 
 	const charset = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789"
-	const length = 8
 	result := make([]byte, length)
 
 	for i := range result {
@@ -47,9 +42,9 @@ func randomString(length int) string {
 func TestCreateServiceAccount(t *testing.T) {
 
 	account := rustfs.ServiceAccount{
-		AccessKey: randomString(),
+		AccessKey: randomString(8),
 		SecretKey: "someSuperS3cret",
-		Name:      randomString(),
+		Name:      randomString(8),
 	}
 	dut := getClient()
 	err := dut.CreateServiceAccount(account)
@@ -61,9 +56,9 @@ func TestCreateServiceAccount(t *testing.T) {
 func TestCreateAndDeleteServiceAccount(t *testing.T) {
 
 	account := rustfs.ServiceAccount{
-		AccessKey: randomString(),
+		AccessKey: randomString(8),
 		SecretKey: "someSuperS3cret",
-		Name:      randomString(),
+		Name:      randomString(8),
 	}
 	dut := getClient()
 	err := dut.CreateServiceAccount(account)
@@ -78,9 +73,9 @@ func TestCreateAndDeleteServiceAccount(t *testing.T) {
 func TestCreateUpdateAndDeleteServiceAccount(t *testing.T) {
 
 	account := rustfs.ServiceAccount{
-		AccessKey: randomString(),
+		AccessKey: randomString(8),
 		SecretKey: "someSuperS3cret",
-		Name:      randomString(),
+		Name:      randomString(8),
 	}
 	dut := getClient()
 	err := dut.CreateServiceAccount(account)
@@ -100,9 +95,9 @@ func TestCreateUpdateAndDeleteServiceAccount(t *testing.T) {
 func TestCreateReadAndDeleteServiceAccount(t *testing.T) {
 
 	account := rustfs.ServiceAccount{
-		AccessKey: randomString(),
+		AccessKey: randomString(8),
 		SecretKey: "someSuperS3cret",
-		Name:      randomString(),
+		Name:      randomString(8),
 	}
 	dut := getClient()
 	err := dut.CreateServiceAccount(account)

--- a/pkg/rustfs/user_account_test.go
+++ b/pkg/rustfs/user_account_test.go
@@ -9,8 +9,8 @@ import (
 func TestCreateUserAccount(t *testing.T) {
 
 	account := rustfs.UserAccount{
-		AccessKey: randomString(),
-		SecretKey: randomString(),
+		AccessKey: randomString(8),
+		SecretKey: randomString(8),
 	}
 	dut := getClient()
 	err := dut.CreateUserAccount(account)
@@ -34,8 +34,8 @@ func TestCreateUserAccount(t *testing.T) {
 func TestCreateUserAccountWithGrp(t *testing.T) {
 
 	account := rustfs.UserAccount{
-		AccessKey: randomString(),
-		SecretKey: randomString(),
+		AccessKey: randomString(8),
+		SecretKey: randomString(8),
 		Policy:    "readwrite",
 	}
 	dut := getClient()
@@ -51,8 +51,8 @@ func TestCreateUserAccountWithGrp(t *testing.T) {
 
 func TestAddUserWithAccesKey(t *testing.T) {
 	account := rustfs.UserAccount{
-		AccessKey: randomString(),
-		SecretKey: randomString(),
+		AccessKey: randomString(8),
+		SecretKey: randomString(8),
 	}
 	dut := getClient()
 	err := dut.CreateUserAccount(account)
@@ -61,9 +61,9 @@ func TestAddUserWithAccesKey(t *testing.T) {
 	}
 
 	service := rustfs.ServiceAccount{
-		AccessKey:  randomString(),
+		AccessKey:  randomString(8),
 		SecretKey:  "someSuperS3cret",
-		Name:       randomString(),
+		Name:       randomString(8),
 		TargetUser: account.AccessKey,
 	}
 	err = dut.CreateServiceAccount(service)

--- a/provider/rustfs_bucket_ressource.go
+++ b/provider/rustfs_bucket_ressource.go
@@ -109,7 +109,6 @@ func (r *bucketRessource) Create(ctx context.Context, req resource.CreateRequest
 		return
 	}
 	tflog.Trace(ctx, "created a resource")
-	// plan.ID = types.StringValue(account.AccessKey)
 	resp.Diagnostics.Append(resp.State.Set(ctx, &plan)...)
 }
 

--- a/provider/rustfs_policy_ressource.go
+++ b/provider/rustfs_policy_ressource.go
@@ -110,8 +110,6 @@ func (r *PolicyRessource) Create(ctx context.Context, req resource.CreateRequest
 		return
 	}
 
-	fmt.Print(plan)
-
 	statements := []rustfs.PolicyStatement{}
 	for _, i := range plan.Statement {
 		statements = append(statements,
@@ -136,7 +134,6 @@ func (r *PolicyRessource) Create(ctx context.Context, req resource.CreateRequest
 		return
 	}
 	tflog.Trace(ctx, "created a resource")
-	// plan.ID = types.StringValue(account.AccessKey)
 	resp.Diagnostics.Append(resp.State.Set(ctx, &plan)...)
 
 }

--- a/provider/rustfs_quota_ressource.go
+++ b/provider/rustfs_quota_ressource.go
@@ -91,7 +91,6 @@ func (r *quotaRessource) Create(ctx context.Context, req resource.CreateRequest,
 		return
 	}
 	tflog.Trace(ctx, "created a resource")
-	// plan.ID = types.StringValue(account.AccessKey)
 	resp.Diagnostics.Append(resp.State.Set(ctx, &plan)...)
 }
 
@@ -109,7 +108,14 @@ func (r *quotaRessource) Read(ctx context.Context, req resource.ReadRequest, res
 		return
 	}
 	// Read
-	read, _ := r.client.RustClient.ReadQuota(state.Bucket.ValueString())
+	read, err := r.client.RustClient.ReadQuota(state.Bucket.ValueString())
+	if err != nil {
+		resp.Diagnostics.AddError(
+			"Error reading bucket quota",
+			"Could not read bucket quota, unexpected error: "+err.Error(),
+		)
+		return
+	}
 	// Save update status
 	state.Quota = types.Int64Value(int64(read.Quota))
 	resp.Diagnostics.Append(resp.State.Set(ctx, &state)...)
@@ -127,8 +133,8 @@ func (r *quotaRessource) Update(ctx context.Context, req resource.UpdateRequest,
 		return
 	}
 
-	q := rustfs.Quota{Bucket: plan.Bucket.ValueString(), Quota: int(plan.Quota.ValueInt64()), Quota_Type: "HARD"}
-	read, err := r.client.RustClient.SetQuota(q)
+	quota := rustfs.Quota{Bucket: plan.Bucket.ValueString(), Quota: int(plan.Quota.ValueInt64()), Quota_Type: "HARD"}
+	read, err := r.client.RustClient.SetQuota(quota)
 	if err != nil {
 		resp.Diagnostics.AddError(
 			"Error updating bucket quota",

--- a/provider/rustfs_user_resource.go
+++ b/provider/rustfs_user_resource.go
@@ -118,9 +118,7 @@ func (r *RustfsUserRessource) Create(ctx context.Context, req resource.CreateReq
 		return
 	}
 	tflog.Trace(ctx, "created a resource")
-	// plan.ID = types.StringValue(account.AccessKey)
 	resp.Diagnostics.Append(resp.State.Set(ctx, &plan)...)
-	// plan.LastUpdated = types.StringValue(time.Now().Format(time.RFC850))
 }
 
 func (r *RustfsUserRessource) Read(ctx context.Context, req resource.ReadRequest, resp *resource.ReadResponse) {
@@ -148,7 +146,6 @@ func (r *RustfsUserRessource) Read(ctx context.Context, req resource.ReadRequest
 	state.AccessKey = types.StringValue(state.AccessKey.ValueString())
 	state.SecretKey = types.StringValue(state.SecretKey.ValueString())
 	state.Policy = types.StringValue(read.Policy)
-	// state.ID = types.StringValue(state.ID.ValueString())
 
 	// Save updated data into Terraform state
 	resp.Diagnostics.Append(resp.State.Set(ctx, &state)...)


### PR DESCRIPTION
Fixes #38

## Fixes

### Quota error handling
- `rustfs_quota` `Read` — now checks `ReadQuota` error instead of silently ignoring it with `_`
- `rustfs_quota` `Update` — now checks `SetQuota` error instead of silently ignoring it with `_`

### Removed debug output
- `rustfs_policy` — removed `fmt.Print(plan)` that printed policy data to stdout on every create

### Removed dead commented-out code
- `provider.go` — removed commented-out error handling block
- All 5 resource files — removed `// plan.ID = ...` and `// state.ID = ...` dead code

### Test fixes
- Tests now use `RUSTFS_USER` env var instead of inconsistent `RUSTFS_KEY`
- Replaced deprecated `rand.Seed()` with `rand.New(rand.NewSource(...))`
- Fixed `time.Sleep(5)` (5 nanoseconds) to `time.Sleep(5 * time.Second)` in quota tests