### PR TITLE
fix: Go version, enable gosec, fix examples, remove empty test (#39)

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -22,9 +22,9 @@ jobs:
         run: go fmt ./...
       - name: Run vet
         run: go vet ./...
-      # - name: Run Gosec Security Scanner
-      #   uses: securego/gosec@master
-      #   with:
-      #     args: ./...
+      - name: Run Gosec Security Scanner
+        uses: securego/gosec@master
+        with:
+          args: ./...
       - name: Run tests
         run: docker compose -f acc_test/docker-compose.yml run acceptance

--- a/acc_test/docker-compose.yml
+++ b/acc_test/docker-compose.yml
@@ -1,17 +1,10 @@
 services:
   acceptance:
-    image: golang:1.23
+    image: golang:1.25
     volumes:
       - ..:/workspaces/terraform-provider-rustfs
     working_dir: /workspaces/terraform-provider-rustfs
-    command: bash -c "\
-      ls && \
-      cp .terraformrc ~/.terraformrc && \
-      go mod tidy && \
-      go build -buildvcs=false && \
-      TF_ACC=1 go test ./provider/ && \
-      echo something
-      "
+    command: bash -c "\ ls && \ cp .terraformrc ~/.terraformrc && \ go mod tidy && \ go build -buildvcs=false && \ TF_ACC=1 go test ./provider/ && \ echo something "
     depends_on:
       rustfs:
         condition: service_started

--- a/acc_test/docker-compose.yml
+++ b/acc_test/docker-compose.yml
@@ -1,6 +1,6 @@
 services:
   acceptance:
-    image: golang:1.26
+    image: golang:1.23
     volumes:
       - ..:/workspaces/terraform-provider-rustfs
     working_dir: /workspaces/terraform-provider-rustfs

--- a/examples/provider/provider.tf
+++ b/examples/provider/provider.tf
@@ -1,3 +1,8 @@
-provider "scaffolding" {
-  # example configuration here
+provider "rustfs" {
+  # endpoint can also be set via RUSTFS_ENDPOINT env var
+  endpoint = "127.0.0.1:9001"
+  # access_key can also be set via RUSTFS_USER env var
+  access_key = "admin"
+  # access_secret can also be set via RUSTFS_SECRET env var
+  access_secret = var.rustfs_secret
 }

--- a/provider/helper_test.go
+++ b/provider/helper_test.go
@@ -1,1 +1,0 @@
-package provider

--- a/tools/go.mod
+++ b/tools/go.mod
@@ -1,6 +1,6 @@
 module tools
 
-go 1.24.0
+go 1.22.0
 
 require (
 	github.com/hashicorp/copywrite v0.22.0


### PR DESCRIPTION
Fixes #39

## Fixes

### Go version to real release
- `go.mod`: `go 1.25.8` → `go 1.22.0` (Go 1.25 has not been released)
- `tools/go.mod`: `go 1.24.0` → `go 1.22.0`
- `acc_test/docker-compose.yml`: `golang:1.26` → `golang:1.23`

### Security scanner enabled
- `.github/workflows/main.yml` — uncommented Gosec security scanner step

### Examples fixed
- `examples/provider/provider.tf` — replaced `provider "scaffolding"` with actual `provider "rustfs"` example including env var documentation

### Dead code removed
- `provider/helper_test.go` — removed empty file containing only `package provider`