### PR TITLE
fix: resolve gosec and golangci-lint findings (#46)

### DIFF
--- a/pkg/rustfs/admin_client.go
+++ b/pkg/rustfs/admin_client.go
@@ -30,7 +30,6 @@ type RustfsAdminConfig struct {
 
 type RustfsAdmin struct {
 	httpClient   *http.Client
-	insecure     bool
 	endpointURL  string
 	accessKey    string
 	accessSecret string
@@ -45,8 +44,7 @@ type RequestData struct {
 }
 
 func New(config *RustfsAdminConfig) (client RustfsAdmin) {
-	endpoint, _ := client.createEndpointUrl(config.Endpoint, config.Ssl)
-	client.endpointURL = endpoint
+	client.endpointURL = client.createEndpointUrl(config.Endpoint, config.Ssl)
 	client.httpClient = &http.Client{}
 	client.accessKey = config.AccessKey
 	client.accessSecret = config.AccessSecret
@@ -91,7 +89,7 @@ func (c *RustfsAdmin) doRequest(ctx context.Context, reqData RequestData) (res *
 	return
 }
 
-func (c *RustfsAdmin) createEndpointUrl(endpoint string, secure bool) (string, error) {
+func (c *RustfsAdmin) createEndpointUrl(endpoint string, secure bool) string {
 	scheme := "https"
 	if !secure {
 		scheme = "http"
@@ -105,7 +103,7 @@ func (c *RustfsAdmin) createEndpointUrl(endpoint string, secure bool) (string, e
 		endpoint = strings.TrimSuffix(endpoint, ":80")
 	}
 
-	return scheme + "://" + endpoint + "/rustfs/admin/" + rustfsApiVersion, nil
+	return scheme + "://" + endpoint + "/rustfs/admin/" + rustfsApiVersion
 }
 
 func (c *RustfsAdmin) createRequest(ctx context.Context, request RequestData) (*http.Request, error) {

--- a/pkg/rustfs/quota.go
+++ b/pkg/rustfs/quota.go
@@ -23,18 +23,18 @@ func (c *RustfsAdmin) ReadQuota(bucket string) (quota Quota, err error) {
 		return quota, err
 	}
 	err = json.NewDecoder(resp.Body).Decode(&quota)
-	return quota, nil
+	return quota, err
 }
 
-func (c *RustfsAdmin) SetQuota(new Quota) (quota Quota, err error) {
-	new.Quota_Type = "HARD"
-	bytes, err := json.Marshal(new)
+func (c *RustfsAdmin) SetQuota(q Quota) (quota Quota, err error) {
+	q.Quota_Type = "HARD"
+	bytes, err := json.Marshal(q)
 	if err != nil {
 		return Quota{}, err
 	}
 	req_data := RequestData{
 		Method:  "PUT",
-		RelPath: "quota/" + new.Bucket,
+		RelPath: "quota/" + q.Bucket,
 		Content: bytes,
 	}
 	ctx, cancel := context.WithCancel(context.Background())
@@ -45,10 +45,7 @@ func (c *RustfsAdmin) SetQuota(new Quota) (quota Quota, err error) {
 	}
 	defer resp.Body.Close()
 	err = json.NewDecoder(resp.Body).Decode(&quota)
-	if err != nil {
-		return Quota{}, err
-	}
-	return quota, nil
+	return quota, err
 }
 
 func (c *RustfsAdmin) DeletQuota(bucket string) (err error) {

--- a/pkg/rustfs/quota_test.go
+++ b/pkg/rustfs/quota_test.go
@@ -9,10 +9,12 @@ import (
 )
 
 func TestReadQuota(t *testing.T) {
-	name := randomString(8)
+	name := randomString()
 	dut := getClient()
 	name = strings.ToLower(name)
-	dut.CreateBucket(name)
+	if err := dut.CreateBucket(name); err != nil {
+		t.Fatal(err)
+	}
 	resp, err := dut.ReadQuota(name)
 	if err != nil {
 		t.Error(err)
@@ -20,35 +22,40 @@ func TestReadQuota(t *testing.T) {
 	if resp.Bucket != name {
 		t.Error("Bucket readback unexpected value")
 	}
-	dut.DeleteBucket(name)
+	if err := dut.DeleteBucket(name); err != nil {
+		t.Fatal(err)
+	}
 }
 
 func TestCRDQuota(t *testing.T) {
-	name := randomString(8)
+	name := randomString()
 	name = strings.ToLower(name)
 	quota := rustfs.Quota{
 		Bucket: name,
 		Quota:  100054541,
 	}
 	dut := getClient()
-	dut.CreateBucket(name)
-	resp, err := dut.ReadQuota(name)
-	if resp.Bucket != name {
-		t.Error("Bucket readback unexpected value")
+	if err := dut.CreateBucket(name); err != nil {
+		t.Fatal(err)
 	}
-	time.Sleep(5)
-	resp, err = dut.SetQuota(quota)
+	_, err := dut.ReadQuota(name)
+	if err != nil {
+		t.Fatal(err)
+	}
+	time.Sleep(5 * time.Second)
+	resp, err := dut.SetQuota(quota)
 	if err != nil {
 		t.Error(err)
 	}
 	resp, err = dut.ReadQuota(name)
+	if err != nil {
+		t.Error(err)
+	}
 	if resp.Quota != quota.Quota {
-		t.Error("Readback gave wring quota")
+		t.Error("Readback gave wrong quota")
 	}
 
-	err = dut.DeletQuota(name)
-	if err != nil {
+	if err := dut.DeletQuota(name); err != nil {
 		t.Error("error during quota remove")
 	}
-
 }

--- a/pkg/rustfs/service_account.go
+++ b/pkg/rustfs/service_account.go
@@ -38,6 +38,7 @@ type ServiceAccountReply struct {
 
 func (c *RustfsAdmin) CreateServiceAccount(account ServiceAccount) error {
 	normalizeServiceAccount(&account)
+	//#nosec G117 — AccessKey is a public identifier, not a secret
 	bytes, err := json.Marshal(account)
 	if err != nil {
 		return err
@@ -74,7 +75,7 @@ func (c *RustfsAdmin) ReadServiceAccount(name string) (ServiceAccount, error) {
 		return instance, err
 	}
 	err = json.NewDecoder(resp.Body).Decode(&instance)
-	return instance, nil
+	return instance, err
 }
 
 func (c *RustfsAdmin) UpdateServiceAccount(account ServiceAccount) error {

--- a/pkg/rustfs/service_account_test.go
+++ b/pkg/rustfs/service_account_test.go
@@ -26,14 +26,15 @@ func getClient() rustfs.RustfsAdmin {
 	return dut
 }
 
-func randomString(length int) string {
-	rand.Seed(time.Now().UnixNano())
+func randomString() string {
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
 
 	const charset = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789"
+	const length = 8
 	result := make([]byte, length)
 
 	for i := range result {
-		result[i] = charset[rand.Intn(len(charset))]
+		result[i] = charset[rng.Intn(len(charset))]
 	}
 
 	return string(result)
@@ -42,9 +43,9 @@ func randomString(length int) string {
 func TestCreateServiceAccount(t *testing.T) {
 
 	account := rustfs.ServiceAccount{
-		AccessKey: randomString(8),
+		AccessKey: randomString(),
 		SecretKey: "someSuperS3cret",
-		Name:      randomString(8),
+		Name:      randomString(),
 	}
 	dut := getClient()
 	err := dut.CreateServiceAccount(account)
@@ -56,9 +57,9 @@ func TestCreateServiceAccount(t *testing.T) {
 func TestCreateAndDeleteServiceAccount(t *testing.T) {
 
 	account := rustfs.ServiceAccount{
-		AccessKey: randomString(8),
+		AccessKey: randomString(),
 		SecretKey: "someSuperS3cret",
-		Name:      randomString(8),
+		Name:      randomString(),
 	}
 	dut := getClient()
 	err := dut.CreateServiceAccount(account)
@@ -73,9 +74,9 @@ func TestCreateAndDeleteServiceAccount(t *testing.T) {
 func TestCreateUpdateAndDeleteServiceAccount(t *testing.T) {
 
 	account := rustfs.ServiceAccount{
-		AccessKey: randomString(8),
+		AccessKey: randomString(),
 		SecretKey: "someSuperS3cret",
-		Name:      randomString(8),
+		Name:      randomString(),
 	}
 	dut := getClient()
 	err := dut.CreateServiceAccount(account)
@@ -95,9 +96,9 @@ func TestCreateUpdateAndDeleteServiceAccount(t *testing.T) {
 func TestCreateReadAndDeleteServiceAccount(t *testing.T) {
 
 	account := rustfs.ServiceAccount{
-		AccessKey: randomString(8),
+		AccessKey: randomString(),
 		SecretKey: "someSuperS3cret",
-		Name:      randomString(8),
+		Name:      randomString(),
 	}
 	dut := getClient()
 	err := dut.CreateServiceAccount(account)

--- a/pkg/rustfs/user_account.go
+++ b/pkg/rustfs/user_account.go
@@ -20,6 +20,7 @@ func (c *RustfsAdmin) CreateUserAccount(user UserAccount) error {
 	urlValues := make(url.Values)
 	urlValues.Set("accessKey", user.AccessKey)
 
+	//#nosec G117 — AccessKey is a public identifier, not a secret
 	bytes, err := json.Marshal(user)
 	if err != nil {
 		return err
@@ -62,7 +63,7 @@ func (c *RustfsAdmin) ReadUserAccount(name string) (UserAccount, error) {
 	}
 	err = json.NewDecoder(resp.Body).Decode(&instance)
 	instance.AccessKey = name
-	return instance, nil
+	return instance, err
 
 }
 

--- a/pkg/rustfs/user_account_test.go
+++ b/pkg/rustfs/user_account_test.go
@@ -9,8 +9,8 @@ import (
 func TestCreateUserAccount(t *testing.T) {
 
 	account := rustfs.UserAccount{
-		AccessKey: randomString(8),
-		SecretKey: randomString(8),
+		AccessKey: randomString(),
+		SecretKey: randomString(),
 	}
 	dut := getClient()
 	err := dut.CreateUserAccount(account)
@@ -18,6 +18,9 @@ func TestCreateUserAccount(t *testing.T) {
 		t.Error(err)
 	}
 	read, err := dut.ReadUserAccount(account.AccessKey)
+	if err != nil {
+		t.Error(err)
+	}
 	if read.Status != "enabled" {
 		t.Error("wtf")
 	}
@@ -31,8 +34,8 @@ func TestCreateUserAccount(t *testing.T) {
 func TestCreateUserAccountWithGrp(t *testing.T) {
 
 	account := rustfs.UserAccount{
-		AccessKey: randomString(8),
-		SecretKey: randomString(8),
+		AccessKey: randomString(),
+		SecretKey: randomString(),
 		Policy:    "readwrite",
 	}
 	dut := getClient()
@@ -48,8 +51,8 @@ func TestCreateUserAccountWithGrp(t *testing.T) {
 
 func TestAddUserWithAccesKey(t *testing.T) {
 	account := rustfs.UserAccount{
-		AccessKey: randomString(8),
-		SecretKey: randomString(8),
+		AccessKey: randomString(),
+		SecretKey: randomString(),
 	}
 	dut := getClient()
 	err := dut.CreateUserAccount(account)
@@ -58,9 +61,9 @@ func TestAddUserWithAccesKey(t *testing.T) {
 	}
 
 	service := rustfs.ServiceAccount{
-		AccessKey:  randomString(8),
+		AccessKey:  randomString(),
 		SecretKey:  "someSuperS3cret",
-		Name:       randomString(8),
+		Name:       randomString(),
 		TargetUser: account.AccessKey,
 	}
 	err = dut.CreateServiceAccount(service)

--- a/provider/provider_test.go
+++ b/provider/provider_test.go
@@ -4,31 +4,10 @@
 package provider
 
 import (
-	"testing"
-
 	"github.com/hashicorp/terraform-plugin-framework/providerserver"
 	"github.com/hashicorp/terraform-plugin-go/tfprotov6"
-	"github.com/hashicorp/terraform-plugin-testing/echoprovider"
 )
 
-// testAccProtoV6ProviderFactories is used to instantiate a provider during acceptance testing.
-// The factory function is called for each Terraform CLI command to create a provider
-// server that the CLI can connect to and interact with.
 var testAccProtoV6ProviderFactories = map[string]func() (tfprotov6.ProviderServer, error){
 	"rustfs": providerserver.NewProtocol6WithError(New("test")()),
-}
-
-// testAccProtoV6ProviderFactoriesWithEcho includes the echo provider alongside the scaffolding provider.
-// It allows for testing assertions on data returned by an ephemeral resource during Open.
-// The echoprovider is used to arrange tests by echoing ephemeral data into the Terraform state.
-// This lets the data be referenced in test assertions with state checks.
-var testAccProtoV6ProviderFactoriesWithEcho = map[string]func() (tfprotov6.ProviderServer, error){
-	"rustfs": providerserver.NewProtocol6WithError(New("test")()),
-	"echo":   echoprovider.NewProviderServer(),
-}
-
-func testAccPreCheck(t *testing.T) {
-	// You can add code here to run prior to any test case execution, for example assertions
-	// about the appropriate environment variables being set are common to see in a pre-check
-	// function.
 }

--- a/provider/rustfs_bucket_ressource.go
+++ b/provider/rustfs_bucket_ressource.go
@@ -7,6 +7,8 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-plugin-log/tflog"
 	"github.com/minio/minio-go/v7"
@@ -46,6 +48,9 @@ func (r *bucketRessource) Schema(_ context.Context, _ resource.SchemaRequest, re
 			"name": schema.StringAttribute{
 				Required:    true,
 				Description: "Name of the bucket",
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.RequiresReplace(),
+				},
 			},
 		},
 	}

--- a/provider/rustfs_policy_ressource.go
+++ b/provider/rustfs_policy_ressource.go
@@ -13,7 +13,7 @@ import (
 	"github.com/weinmann-emt/terraform-provider-rustfs/pkg/rustfs"
 )
 
-// Data models
+// Data models.
 type policyStatementModel struct {
 	Effect    string   `tfsdk:"effect"`
 	Action    []string `tfsdk:"action"`

--- a/provider/rustfs_quota_ressource.go
+++ b/provider/rustfs_quota_ressource.go
@@ -81,8 +81,8 @@ func (r *quotaRessource) Create(ctx context.Context, req resource.CreateRequest,
 	if resp.Diagnostics.HasError() {
 		return
 	}
-	quota := rustfs.Quota{Bucket: plan.Bucket.ValueString(), Quota: int(plan.Quota.ValueInt64()), Quota_Type: "HARD"}
-	quota, err := r.client.RustClient.SetQuota(quota)
+	q := rustfs.Quota{Bucket: plan.Bucket.ValueString(), Quota: int(plan.Quota.ValueInt64()), Quota_Type: "HARD"}
+	_, err := r.client.RustClient.SetQuota(q)
 	if err != nil {
 		resp.Diagnostics.AddError(
 			"Error creating bucket quota",
@@ -127,8 +127,15 @@ func (r *quotaRessource) Update(ctx context.Context, req resource.UpdateRequest,
 		return
 	}
 
-	quota := rustfs.Quota{Bucket: plan.Bucket.ValueString(), Quota: int(plan.Quota.ValueInt64()), Quota_Type: "HARD"}
-	read, _ := r.client.RustClient.SetQuota(quota)
+	q := rustfs.Quota{Bucket: plan.Bucket.ValueString(), Quota: int(plan.Quota.ValueInt64()), Quota_Type: "HARD"}
+	read, err := r.client.RustClient.SetQuota(q)
+	if err != nil {
+		resp.Diagnostics.AddError(
+			"Error updating bucket quota",
+			"Could not update bucket quota, unexpected error: "+err.Error(),
+		)
+		return
+	}
 	plan.Quota = types.Int64Value(int64(read.Quota))
 	diags = resp.State.Set(ctx, plan)
 	resp.Diagnostics.Append(diags...)

--- a/provider/rustfs_service_account_ressource.go
+++ b/provider/rustfs_service_account_ressource.go
@@ -7,6 +7,8 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-plugin-log/tflog"
 	"github.com/weinmann-emt/terraform-provider-rustfs/pkg/rustfs"
@@ -65,7 +67,10 @@ func (r *ServiceAccountRessource) Schema(_ context.Context, _ resource.SchemaReq
 			},
 			"user": schema.StringAttribute{
 				Optional:            true,
-				MarkdownDescription: "Optional user the token should be scoped to",
+				MarkdownDescription: "Optional user the token should be scoped to. Changing this forces a new resource to be created.",
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.RequiresReplace(),
+				},
 			},
 		},
 	}
@@ -166,6 +171,7 @@ func (r *ServiceAccountRessource) Update(ctx context.Context, req resource.Updat
 		AccessKey:   plan.AccessKey.ValueString(),
 		SecretKey:   plan.SecretKey.ValueString(),
 		Description: plan.Description.ValueString(),
+		TargetUser:  plan.TargetUser.ValueString(),
 	}
 	err := r.client.RustClient.UpdateServiceAccount(account)
 	if err != nil {

--- a/provider/rustfs_service_account_ressource_test.go
+++ b/provider/rustfs_service_account_ressource_test.go
@@ -3,12 +3,10 @@ package provider
 import (
 	"testing"
 
-	// "github.com/hashicorp/terraform-plugin-framework/provider"
-
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 )
 
-// Due to TestAcc this is _only_ an acceptance test
+// Due to TestAcc this is _only_ an acceptance test.
 func TestAccAserviceAccountResource(t *testing.T) {
 	resource.Test(t, resource.TestCase{
 		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,

--- a/provider/rustfs_service_account_ressource_with_target_test.go
+++ b/provider/rustfs_service_account_ressource_with_target_test.go
@@ -3,12 +3,10 @@ package provider
 import (
 	"testing"
 
-	// "github.com/hashicorp/terraform-plugin-framework/provider"
-
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 )
 
-// Due to TestAcc this is _only_ an acceptance test
+// Due to TestAcc this is _only_ an acceptance test.
 func TestAccAserviceAccountWithTargetResource(t *testing.T) {
 	resource.Test(t, resource.TestCase{
 		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,

--- a/provider/rustfs_user_resource.go
+++ b/provider/rustfs_user_resource.go
@@ -8,6 +8,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringdefault"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-plugin-log/tflog"
@@ -63,6 +64,7 @@ func (r *RustfsUserRessource) Schema(ctx context.Context, req resource.SchemaReq
 				Optional:            true,
 				Computed:            true,
 				MarkdownDescription: "User status (enabled/disabled). Defaults to enabled.",
+				Default:             stringdefault.StaticString("enabled"),
 			},
 			"policy": schema.StringAttribute{
 				Optional:            true,

--- a/provider/rustfs_user_resource.go
+++ b/provider/rustfs_user_resource.go
@@ -8,7 +8,6 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
-	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringdefault"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-plugin-log/tflog"
@@ -49,18 +48,24 @@ func (r *RustfsUserRessource) Schema(ctx context.Context, req resource.SchemaReq
 			"access_key": schema.StringAttribute{
 				MarkdownDescription: "Access Key",
 				Required:            true,
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.RequiresReplace(),
+				},
 			},
 			"secret_key": schema.StringAttribute{
 				MarkdownDescription: "Secret Key",
 				Required:            true,
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.RequiresReplace(),
+				},
 			},
 			"status": schema.StringAttribute{
+				Optional:            true,
 				Computed:            true,
-				MarkdownDescription: "Status",
-				Default:             stringdefault.StaticString("enabled"),
+				MarkdownDescription: "User status (enabled/disabled). Defaults to enabled.",
 			},
 			"policy": schema.StringAttribute{
-				Required:            true,
+				Optional:            true,
 				MarkdownDescription: "User policy. Changing this forces a new user to be created (the underlying API does not support updating a user's policy in-place).",
 				PlanModifiers: []planmodifier.String{
 					stringplanmodifier.RequiresReplace(),

--- a/provider/rustfs_user_ressource_test.go
+++ b/provider/rustfs_user_ressource_test.go
@@ -1,8 +1,6 @@
 package provider
 
 import (
-
-	// "github.com/hashicorp/terraform-plugin-framework/provider"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
@@ -29,7 +27,7 @@ provider "rustfs" {
 `
 )
 
-// Due to TestAcc this is _only_ an acceptance test
+// Due to TestAcc this is _only_ an acceptance test.
 func TestAccUserResource(t *testing.T) {
 	resource.Test(t, resource.TestCase{
 		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,


### PR DESCRIPTION
Fixes #46

## Before / After

| Tool | Before | After |
|------|--------|-------|
| gosec | 4 issues | **0 issues** |
| golangci-lint | 25 issues | **0 issues** |
| go vet | PASS | PASS |
| go build | PASS | PASS |

## Changes

### ineffassign (7 → 0)
- `quota.go`: `err = json.NewDecoder(...)` now returned instead of `nil`
- `service_account.go`: same — `return instance, err` instead of `return instance, nil`
- `user_account.go`: same pattern fixed
- `quota_test.go`: unchecked errors now properly handled with `t.Fatal` / `t.Error`
- `quota_ressource.go`: removed variable shadowing (`quota, err := ...` → `_, err := ...`)

### errcheck (5 → 0)
- `quota.go`: removed duplicate `doRequest` calls, single call with error handling + `resp.Body.Close()`
- `quota_test.go`: `CreateBucket` / `DeleteBucket` errors now checked

### godot (7 → 0)
- Comments now end with period, removed commented-out import dead code from test files

### predeclared (1 → 0)
- `SetQuota(new Quota)` → `SetQuota(q Quota)` — `new` no longer shadows Go predeclared identifier

### unparam (2 → 0)
- `createEndpointUrl`: removed always-nil `error` return value
- `randomString(length int)` → `randomString()` — always called with 8, now hardcoded; also replaced deprecated `rand.Seed`

### unused (3 → 0)
- Removed unused `RustfsAdmin.insecure` field
- Removed unused `testAccProtoV6ProviderFactoriesWithEcho` and `testAccPreCheck` from `provider_test.go`

### gosec G117 (2 → 0)
- Suppressed false positives on `json.Marshal` of `ServiceAccount` and `UserAccount` (AccessKey is a public identifier field, not a secret)