### PR TITLE
feat: add rustfs_bucket_versioning resource (#52)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,4 +35,11 @@ website/vendor
 *.winfile eol=crlf
 .env
 terraform-provider-rustfs
+<<<<<<< HEAD
+=======
+
+# Superpowers plans (local only)
+>>>>>>> 7128ec2 (feat: add rustfs_bucket_versioning resource to manage S3 versioning (#52))
 docs/superpowers/
+docs/superpowers/
+

--- a/docs/resources/bucket_versioning.md
+++ b/docs/resources/bucket_versioning.md
@@ -1,0 +1,37 @@
+---
+page_title: "rustfs_bucket_versioning Resource - rustfs"
+description: |-
+  Manage RustFS bucket versioning configuration
+---
+
+# rustfs_bucket_versioning (Resource)
+
+Manage RustFS bucket versioning configuration.
+
+## Example Usage
+
+```terraform
+resource "rustfs_bucket" "example" {
+  name = "my-bucket"
+}
+
+resource "rustfs_bucket_versioning" "example" {
+  bucket = rustfs_bucket.example.name
+  status = "Enabled"
+}
+```
+
+## Schema
+
+### Required
+
+- `bucket` (String) Name of the bucket. Changing this forces a new resource to be created.
+- `status` (String) Versioning status: `Enabled` or `Suspended`.
+
+## Import
+
+Import is supported using the bucket name:
+
+```
+terraform import rustfs_bucket_versioning.example my-bucket
+```

--- a/examples/resources/rustfs_bucket_versioning/resource.tf
+++ b/examples/resources/rustfs_bucket_versioning/resource.tf
@@ -1,0 +1,8 @@
+resource "rustfs_bucket" "example" {
+  name = "my-versioned-bucket"
+}
+
+resource "rustfs_bucket_versioning" "example" {
+  bucket = rustfs_bucket.example.name
+  status = "Enabled"
+}

--- a/provider/provider.go
+++ b/provider/provider.go
@@ -128,6 +128,7 @@ func (p *RustfsProvider) Resources(ctx context.Context) []func() resource.Resour
 		NewquotaRessource,
 		NewBucketLifecycleConfigurationRessource,
 		NewBucketObjectLockResource,
+		NewBucketVersioningResource,
 	}
 }
 

--- a/provider/rustfs_bucket_versioning_resource.go
+++ b/provider/rustfs_bucket_versioning_resource.go
@@ -1,0 +1,156 @@
+package provider
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/hashicorp/terraform-plugin-framework/path"
+	"github.com/hashicorp/terraform-plugin-framework/resource"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/hashicorp/terraform-plugin-log/tflog"
+	"github.com/minio/minio-go/v7"
+)
+
+var (
+	_ resource.Resource                = &BucketVersioningResource{}
+	_ resource.ResourceWithImportState = &BucketVersioningResource{}
+)
+
+type BucketVersioningResource struct {
+	client *AllClient
+}
+
+type BucketVersioningResourceModel struct {
+	Bucket types.String `tfsdk:"bucket"`
+	Status types.String `tfsdk:"status"`
+}
+
+func NewBucketVersioningResource() resource.Resource {
+	return &BucketVersioningResource{}
+}
+
+func (r *BucketVersioningResource) Metadata(_ context.Context, req resource.MetadataRequest, resp *resource.MetadataResponse) {
+	resp.TypeName = req.ProviderTypeName + "_bucket_versioning"
+}
+
+func (r *BucketVersioningResource) Schema(_ context.Context, _ resource.SchemaRequest, resp *resource.SchemaResponse) {
+	resp.Schema = schema.Schema{
+		Description:         "Manage RustFS bucket versioning",
+		MarkdownDescription: "Manage RustFS bucket versioning configuration",
+		Attributes: map[string]schema.Attribute{
+			"bucket": schema.StringAttribute{
+				Required:    true,
+				Description: "Name of the bucket.",
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.RequiresReplace(),
+				},
+			},
+			"status": schema.StringAttribute{
+				Required:    true,
+				Description: "Versioning status: Enabled or Suspended.",
+			},
+		},
+	}
+}
+
+func (r *BucketVersioningResource) Configure(_ context.Context, req resource.ConfigureRequest, resp *resource.ConfigureResponse) {
+	if req.ProviderData == nil {
+		return
+	}
+	client, ok := req.ProviderData.(*AllClient)
+	if !ok {
+		resp.Diagnostics.AddError(
+			"Unexpected Resource Configure Type",
+			fmt.Sprintf("Expected *AllClient, got: %T.", req.ProviderData),
+		)
+		return
+	}
+	r.client = client
+}
+
+func (r *BucketVersioningResource) Create(ctx context.Context, req resource.CreateRequest, resp *resource.CreateResponse) {
+	var plan BucketVersioningResourceModel
+	resp.Diagnostics.Append(req.Plan.Get(ctx, &plan)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	err := r.client.Minio.SetBucketVersioning(ctx, plan.Bucket.ValueString(), minio.BucketVersioningConfiguration{
+		Status: plan.Status.ValueString(),
+	})
+	if err != nil {
+		resp.Diagnostics.AddError(
+			"Error setting bucket versioning",
+			"Could not set bucket versioning: "+err.Error(),
+		)
+		return
+	}
+
+	tflog.Trace(ctx, "created bucket versioning")
+	resp.Diagnostics.Append(resp.State.Set(ctx, &plan)...)
+}
+
+func (r *BucketVersioningResource) Read(ctx context.Context, req resource.ReadRequest, resp *resource.ReadResponse) {
+	var state BucketVersioningResourceModel
+	resp.Diagnostics.Append(req.State.Get(ctx, &state)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	config, err := r.client.Minio.GetBucketVersioning(ctx, state.Bucket.ValueString())
+	if err != nil {
+		resp.Diagnostics.AddError(
+			"Error reading bucket versioning",
+			"Could not read bucket versioning: "+err.Error(),
+		)
+		return
+	}
+
+	state.Status = types.StringValue(config.Status)
+	resp.Diagnostics.Append(resp.State.Set(ctx, &state)...)
+}
+
+func (r *BucketVersioningResource) Update(ctx context.Context, req resource.UpdateRequest, resp *resource.UpdateResponse) {
+	var plan BucketVersioningResourceModel
+	resp.Diagnostics.Append(req.Plan.Get(ctx, &plan)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	err := r.client.Minio.SetBucketVersioning(ctx, plan.Bucket.ValueString(), minio.BucketVersioningConfiguration{
+		Status: plan.Status.ValueString(),
+	})
+	if err != nil {
+		resp.Diagnostics.AddError(
+			"Error updating bucket versioning",
+			"Could not update bucket versioning: "+err.Error(),
+		)
+		return
+	}
+
+	resp.Diagnostics.Append(resp.State.Set(ctx, &plan)...)
+}
+
+func (r *BucketVersioningResource) Delete(ctx context.Context, req resource.DeleteRequest, resp *resource.DeleteResponse) {
+	var data BucketVersioningResourceModel
+	resp.Diagnostics.Append(req.State.Get(ctx, &data)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	err := r.client.Minio.SuspendVersioning(ctx, data.Bucket.ValueString())
+	if err != nil {
+		resp.Diagnostics.AddError(
+			"Error suspending bucket versioning",
+			"Could not suspend bucket versioning: "+err.Error(),
+		)
+		return
+	}
+}
+
+func (r *BucketVersioningResource) ImportState(ctx context.Context, req resource.ImportStateRequest, resp *resource.ImportStateResponse) {
+	resource.ImportStatePassthroughID(ctx, path.Root("bucket"), req, resp)
+}

--- a/provider/rustfs_bucket_versioning_resource_test.go
+++ b/provider/rustfs_bucket_versioning_resource_test.go
@@ -1,0 +1,35 @@
+package provider
+
+import (
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-framework/resource"
+)
+
+func TestBucketVersioningResourceSchema(t *testing.T) {
+	r := NewBucketVersioningResource()
+	resp := &resource.SchemaResponse{}
+	r.Schema(nil, resource.SchemaRequest{}, resp)
+
+	if diags := resp.Diagnostics; diags.HasError() {
+		t.Fatalf("schema diagnostics: %v", diags)
+	}
+
+	attrs := resp.Schema.GetAttributes()
+	if _, ok := attrs["bucket"]; !ok {
+		t.Error("expected bucket attribute")
+	}
+	if _, ok := attrs["status"]; !ok {
+		t.Error("expected status attribute")
+	}
+}
+
+func TestBucketVersioningResourceMetadata(t *testing.T) {
+	r := NewBucketVersioningResource()
+	resp := &resource.MetadataResponse{}
+	r.Metadata(nil, resource.MetadataRequest{ProviderTypeName: "rustfs"}, resp)
+
+	if resp.TypeName != "rustfs_bucket_versioning" {
+		t.Errorf("expected rustfs_bucket_versioning, got %s", resp.TypeName)
+	}
+}


### PR DESCRIPTION
Fixes #52

## Feature

New `rustfs_bucket_versioning` resource to manage S3 bucket versioning.

## Usage

```terraform
resource "rustfs_bucket" "example" {
  name = "my-bucket"
}

resource "rustfs_bucket_versioning" "example" {
  bucket = rustfs_bucket.example.name
  status = "Enabled"
}
```

## API

Uses Minio Go client `GetBucketVersioning` / `SetBucketVersioning` / `SuspendVersioning`.

## Schema

- `bucket` — Required, RequiresReplace (immutable)
- `status` — Required — "Enabled" or "Suspended"

## Operations
- Create: Enable versioning on bucket
- Read: Get current versioning status
- Update: Change versioning status
- Delete: Suspend versioning (set to Suspended)
- Import: `terraform import rustfs_bucket_versioning.example my-bucket`