### PR TITLE
feat: add rustfs_users data source (#51)

### DIFF
--- a/docs/data-sources/users.md
+++ b/docs/data-sources/users.md
@@ -1,0 +1,26 @@
+---
+page_title: "rustfs_users Data Source - rustfs"
+description: |-
+  List RustFS IAM users
+---
+
+# rustfs_users (Data Source)
+
+List all RustFS IAM users, optionally filtered by bucket name.
+
+## Example Usage
+
+```terraform
+data "rustfs_users" "all" {}
+output "all_users" { value = data.rustfs_users.all.access_keys }
+```
+
+## Schema
+
+### Optional
+
+- `bucket` (String) Filter users by bucket name.
+
+### Read-Only
+
+- `access_keys` (List of String) List of user access keys.

--- a/examples/data-sources/rustfs_users/data-source.tf
+++ b/examples/data-sources/rustfs_users/data-source.tf
@@ -1,0 +1,11 @@
+# List all users
+data "rustfs_users" "all" {}
+
+output "all_user_keys" {
+  value = data.rustfs_users.all.access_keys
+}
+
+# Filter users by bucket
+data "rustfs_users" "bucket_users" {
+  bucket = "my-bucket"
+}

--- a/pkg/rustfs/user_list.go
+++ b/pkg/rustfs/user_list.go
@@ -1,0 +1,35 @@
+package rustfs
+
+import (
+	"context"
+	"encoding/json"
+	"net/url"
+)
+
+type UserInfo struct {
+	AccessKey string `json:"accessKey"`
+	Status    string `json:"status"`
+	Policy    string `json:"policyName"`
+}
+
+func (c *RustfsAdmin) ListUsers(bucket string) ([]UserInfo, error) {
+	query := url.Values{}
+	if bucket != "" {
+		query.Set("bucket", bucket)
+	}
+	reqData := RequestData{
+		Method:      "GET",
+		RelPath:     "list-users",
+		QueryValues: query,
+	}
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	resp, err := c.doRequest(ctx, reqData)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+	var users []UserInfo
+	err = json.NewDecoder(resp.Body).Decode(&users)
+	return users, err
+}

--- a/pkg/rustfs/user_list_test.go
+++ b/pkg/rustfs/user_list_test.go
@@ -1,0 +1,69 @@
+package rustfs
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func TestListUsers(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodGet {
+			t.Errorf("expected GET, got %s", r.Method)
+		}
+		users := []UserInfo{
+			{AccessKey: "alice", Status: "enabled", Policy: "readwrite"},
+			{AccessKey: "bob", Status: "disabled", Policy: "readonly"},
+		}
+		w.WriteHeader(http.StatusOK)
+		json.NewEncoder(w).Encode(users)
+	}))
+	defer server.Close()
+
+	client := New(&RustfsAdminConfig{
+		Endpoint:  server.Listener.Addr().String(),
+		AccessKey: "admin",
+	})
+	client.accessSecret = "secret"
+
+	users, err := client.ListUsers("")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(users) != 2 {
+		t.Fatalf("expected 2 users, got %d", len(users))
+	}
+	if users[0].AccessKey != "alice" {
+		t.Errorf("expected alice, got %s", users[0].AccessKey)
+	}
+	if users[1].Status != "disabled" {
+		t.Errorf("expected disabled, got %s", users[1].Status)
+	}
+}
+
+func TestListUsersWithBucket(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		bucket := r.URL.Query().Get("bucket")
+		if bucket != "my-bucket" {
+			t.Errorf("expected bucket=my-bucket, got %s", bucket)
+		}
+		w.WriteHeader(http.StatusOK)
+		json.NewEncoder(w).Encode([]UserInfo{})
+	}))
+	defer server.Close()
+
+	client := New(&RustfsAdminConfig{
+		Endpoint:  server.Listener.Addr().String(),
+		AccessKey: "admin",
+	})
+	client.accessSecret = "secret"
+
+	users, err := client.ListUsers("my-bucket")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(users) != 0 {
+		t.Fatalf("expected 0 users, got %d", len(users))
+	}
+}

--- a/provider/provider.go
+++ b/provider/provider.go
@@ -134,6 +134,7 @@ func (p *RustfsProvider) Resources(ctx context.Context) []func() resource.Resour
 func (p *RustfsProvider) DataSources(ctx context.Context) []func() datasource.DataSource {
 	return []func() datasource.DataSource{
 		NewPoolsDataSource,
+		NewUsersDataSource,
 	}
 }
 

--- a/provider/rustfs_users_datasource.go
+++ b/provider/rustfs_users_datasource.go
@@ -1,0 +1,90 @@
+package provider
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/hashicorp/terraform-plugin-framework/datasource"
+	"github.com/hashicorp/terraform-plugin-framework/datasource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+)
+
+var _ datasource.DataSource = &UsersDataSource{}
+
+type UsersDataSource struct {
+	client *AllClient
+}
+
+type UsersDataSourceModel struct {
+	Bucket     types.String `tfsdk:"bucket"`
+	AccessKeys types.List   `tfsdk:"access_keys"`
+}
+
+func NewUsersDataSource() datasource.DataSource {
+	return &UsersDataSource{}
+}
+
+func (d *UsersDataSource) Metadata(_ context.Context, req datasource.MetadataRequest, resp *datasource.MetadataResponse) {
+	resp.TypeName = req.ProviderTypeName + "_users"
+}
+
+func (d *UsersDataSource) Schema(_ context.Context, _ datasource.SchemaRequest, resp *datasource.SchemaResponse) {
+	resp.Schema = schema.Schema{
+		Description:         "List RustFS IAM users",
+		MarkdownDescription: "List all RustFS IAM users, optionally filtered by bucket name",
+		Attributes: map[string]schema.Attribute{
+			"bucket": schema.StringAttribute{
+				Optional:    true,
+				Description: "Filter users by bucket name.",
+			},
+			"access_keys": schema.ListAttribute{
+				Computed:    true,
+				ElementType: types.StringType,
+				Description: "List of user access keys.",
+			},
+		},
+	}
+}
+
+func (d *UsersDataSource) Configure(_ context.Context, req datasource.ConfigureRequest, resp *datasource.ConfigureResponse) {
+	if req.ProviderData == nil {
+		return
+	}
+	client, ok := req.ProviderData.(*AllClient)
+	if !ok {
+		resp.Diagnostics.AddError(
+			"Unexpected Data Source Configure Type",
+			fmt.Sprintf("Expected *AllClient, got: %T.", req.ProviderData),
+		)
+		return
+	}
+	d.client = client
+}
+
+func (d *UsersDataSource) Read(ctx context.Context, req datasource.ReadRequest, resp *datasource.ReadResponse) {
+	var config UsersDataSourceModel
+	resp.Diagnostics.Append(req.Config.Get(ctx, &config)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	users, err := d.client.RustClient.ListUsers(config.Bucket.ValueString())
+	if err != nil {
+		resp.Diagnostics.AddError(
+			"Error listing users",
+			"Could not list users: "+err.Error(),
+		)
+		return
+	}
+
+	var keys []string
+	for _, u := range users {
+		keys = append(keys, u.AccessKey)
+	}
+
+	accessKeys, diags := types.ListValueFrom(ctx, types.StringType, keys)
+	resp.Diagnostics.Append(diags...)
+
+	config.AccessKeys = accessKeys
+	resp.Diagnostics.Append(resp.State.Set(ctx, &config)...)
+}

--- a/provider/rustfs_users_datasource_test.go
+++ b/provider/rustfs_users_datasource_test.go
@@ -1,0 +1,35 @@
+package provider
+
+import (
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-framework/datasource"
+)
+
+func TestUsersDataSourceSchema(t *testing.T) {
+	d := NewUsersDataSource()
+	resp := &datasource.SchemaResponse{}
+	d.Schema(nil, datasource.SchemaRequest{}, resp)
+
+	if diags := resp.Diagnostics; diags.HasError() {
+		t.Fatalf("schema diagnostics: %v", diags)
+	}
+
+	attrs := resp.Schema.GetAttributes()
+	if _, ok := attrs["bucket"]; !ok {
+		t.Error("expected bucket attribute")
+	}
+	if _, ok := attrs["access_keys"]; !ok {
+		t.Error("expected access_keys attribute")
+	}
+}
+
+func TestUsersDataSourceMetadata(t *testing.T) {
+	d := NewUsersDataSource()
+	resp := &datasource.MetadataResponse{}
+	d.Metadata(nil, datasource.MetadataRequest{ProviderTypeName: "rustfs"}, resp)
+
+	if resp.TypeName != "rustfs_users" {
+		t.Errorf("expected rustfs_users, got %s", resp.TypeName)
+	}
+}


### PR DESCRIPTION
Fixes #51

## Feature

New `rustfs_users` data source to list RustFS IAM users.

## Usage

```terraform
data "rustfs_users" "all" {}
output "all_users" { value = data.rustfs_users.all.access_keys }
```

Optionally filter by bucket:

```terraform
data "rustfs_users" "bucket_users" {
  bucket = "my-bucket"
}
```

## API

Uses `GET /v3/list-users` with optional `?bucket={name}` query parameter.

## Schema

- `bucket` — Optional, filter users by bucket name
- `access_keys` — Computed, List of String — user access keys