### PR TITLE
feat: add Dependabot config for automated dependency updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,29 @@
+version: 2
+updates:
+  - package-ecosystem: "gomod"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+    labels:
+      - "dependencies"
+    open-pull-requests-limit: 5
+
+  - package-ecosystem: "gomod"
+    directory: "/tools"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+    labels:
+      - "dependencies"
+      - "tools"
+    open-pull-requests-limit: 3
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+    labels:
+      - "dependencies"
+      - "ci"

--- a/.gitignore
+++ b/.gitignore
@@ -35,3 +35,4 @@ website/vendor
 *.winfile eol=crlf
 .env
 terraform-provider-rustfs
+docs/superpowers/

--- a/.gitignore
+++ b/.gitignore
@@ -35,4 +35,3 @@ website/vendor
 *.winfile eol=crlf
 .env
 terraform-provider-rustfs
-docs/superpowers/


### PR DESCRIPTION
## Feature

Add Dependabot configuration for automated dependency updates.

## Configuration

### Go modules ()
- Ecosystem: `gomod`
- Schedule: weekly on Monday
- Max open PRs: 5

### Go tools ()
- Ecosystem: `gomod`
- Schedule: weekly on Monday
- Max open PRs: 3

### GitHub Actions
- Ecosystem: `github-actions`
- Schedule: weekly on Monday
- Updates action versions (checkout, setup-go, gosec)

## How it works

Dependabot automatically creates PRs when new versions of dependencies are available. Example:
```
Bump github.com/minio/minio-go/v7 from 7.0.63 to 7.0.71
```

Each PR includes a changelog and compatibility score. Merging is manual by default — the maintainer reviews and approves updates.