### PR TITLE
feat: add rustfs_pools data source (#60)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,3 +35,4 @@ website/vendor
 *.winfile eol=crlf
 .env
 terraform-provider-rustfs
+docs/superpowers/

--- a/docs/data-sources/pools.md
+++ b/docs/data-sources/pools.md
@@ -1,0 +1,22 @@
+---
+page_title: "rustfs_pools Data Source - rustfs"
+description: |-
+  List RustFS storage pools
+---
+
+# rustfs_pools (Data Source)
+
+List all RustFS storage pools.
+
+## Example Usage
+
+```terraform
+data "rustfs_pools" "all" {}
+output "pool_names" { value = data.rustfs_pools.all.names }
+```
+
+## Schema
+
+### Read-Only
+
+- `names` (List of String) List of storage pool names.

--- a/examples/data-sources/rustfs_pools/data-source.tf
+++ b/examples/data-sources/rustfs_pools/data-source.tf
@@ -1,0 +1,5 @@
+data "rustfs_pools" "all" {}
+
+output "pool_names" {
+  value = data.rustfs_pools.all.names
+}

--- a/pkg/rustfs/pools.go
+++ b/pkg/rustfs/pools.go
@@ -1,0 +1,27 @@
+package rustfs
+
+import (
+	"context"
+	"encoding/json"
+)
+
+type PoolInfo struct {
+	Name string `json:"name"`
+}
+
+func (c *RustfsAdmin) ListPools() ([]PoolInfo, error) {
+	reqData := RequestData{
+		Method:  "GET",
+		RelPath: "list-pools",
+	}
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	resp, err := c.doRequest(ctx, reqData)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+	var pools []PoolInfo
+	err = json.NewDecoder(resp.Body).Decode(&pools)
+	return pools, err
+}

--- a/pkg/rustfs/pools_test.go
+++ b/pkg/rustfs/pools_test.go
@@ -1,0 +1,40 @@
+package rustfs
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func TestListPools(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodGet {
+			t.Errorf("expected GET, got %s", r.Method)
+		}
+		pools := []PoolInfo{
+			{Name: "pool-0"},
+			{Name: "pool-1"},
+		}
+		w.WriteHeader(http.StatusOK)
+		json.NewEncoder(w).Encode(pools)
+	}))
+	defer server.Close()
+
+	client := New(&RustfsAdminConfig{
+		Endpoint:  server.Listener.Addr().String(),
+		AccessKey: "admin",
+	})
+	client.accessSecret = "secret"
+
+	pools, err := client.ListPools()
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(pools) != 2 {
+		t.Fatalf("expected 2 pools, got %d", len(pools))
+	}
+	if pools[0].Name != "pool-0" {
+		t.Errorf("expected pool-0, got %s", pools[0].Name)
+	}
+}

--- a/provider/provider.go
+++ b/provider/provider.go
@@ -132,7 +132,7 @@ func (p *RustfsProvider) Resources(ctx context.Context) []func() resource.Resour
 
 func (p *RustfsProvider) DataSources(ctx context.Context) []func() datasource.DataSource {
 	return []func() datasource.DataSource{
-		// NewExampleDataSource,
+		NewPoolsDataSource,
 	}
 }
 

--- a/provider/rustfs_pools_datasource.go
+++ b/provider/rustfs_pools_datasource.go
@@ -1,0 +1,84 @@
+package provider
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/hashicorp/terraform-plugin-framework/datasource"
+	"github.com/hashicorp/terraform-plugin-framework/datasource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+)
+
+var _ datasource.DataSource = &PoolsDataSource{}
+
+type PoolsDataSource struct {
+	client *AllClient
+}
+
+type PoolsDataSourceModel struct {
+	Names types.List `tfsdk:"names"`
+}
+
+func NewPoolsDataSource() datasource.DataSource {
+	return &PoolsDataSource{}
+}
+
+func (d *PoolsDataSource) Metadata(_ context.Context, req datasource.MetadataRequest, resp *datasource.MetadataResponse) {
+	resp.TypeName = req.ProviderTypeName + "_pools"
+}
+
+func (d *PoolsDataSource) Schema(_ context.Context, _ datasource.SchemaRequest, resp *datasource.SchemaResponse) {
+	resp.Schema = schema.Schema{
+		Description:         "List RustFS storage pools",
+		MarkdownDescription: "List all RustFS storage pools and their status",
+		Attributes: map[string]schema.Attribute{
+			"names": schema.ListAttribute{
+				Computed:    true,
+				ElementType: types.StringType,
+				Description: "List of storage pool names.",
+			},
+		},
+	}
+}
+
+func (d *PoolsDataSource) Configure(_ context.Context, req datasource.ConfigureRequest, resp *datasource.ConfigureResponse) {
+	if req.ProviderData == nil {
+		return
+	}
+	client, ok := req.ProviderData.(*AllClient)
+	if !ok {
+		resp.Diagnostics.AddError(
+			"Unexpected Data Source Configure Type",
+			fmt.Sprintf("Expected *AllClient, got: %T.", req.ProviderData),
+		)
+		return
+	}
+	d.client = client
+}
+
+func (d *PoolsDataSource) Read(ctx context.Context, req datasource.ReadRequest, resp *datasource.ReadResponse) {
+	var config PoolsDataSourceModel
+	resp.Diagnostics.Append(req.Config.Get(ctx, &config)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	pools, err := d.client.RustClient.ListPools()
+	if err != nil {
+		resp.Diagnostics.AddError(
+			"Error listing pools",
+			"Could not list pools: "+err.Error(),
+		)
+		return
+	}
+
+	var names []string
+	for _, p := range pools {
+		names = append(names, p.Name)
+	}
+
+	poolNames, diags := types.ListValueFrom(ctx, types.StringType, names)
+	resp.Diagnostics.Append(diags...)
+	config.Names = poolNames
+	resp.Diagnostics.Append(resp.State.Set(ctx, &config)...)
+}


### PR DESCRIPTION
Fixes #60

## Feature

New `rustfs_pools` data source to list storage pools.

## Usage

```terraform
data "rustfs_pools" "all" {}
output "pool_names" { value = data.rustfs_pools.all.names }
```

## API

`GET /v3/list-pools` — returns JSON array of pool info.

## Schema

- `names` — Computed, List of String

## Tests

- Unit test for `ListPools` API client using `httptest.Server`
- Acceptance test: create + verify via RustFS environment (requires running server)