### PR TITLE
feat: add rustfs_tier resource for storage tier management (#57)

### DIFF
--- a/docs/resources/tier.md
+++ b/docs/resources/tier.md
@@ -1,0 +1,44 @@
+---
+page_title: "rustfs_tier Resource - rustfs"
+description: |-
+  Manage RustFS storage tiers
+---
+
+# rustfs_tier (Resource)
+
+Manage RustFS storage tiers for data transition to external backends (S3, Azure, GCS, MinIO, etc.).
+
+## Example Usage
+
+```terraform
+resource "rustfs_tier" "s3_cold" {
+  name      = "S3COLD"
+  tier_type = "s3"
+  config_json = jsonencode({
+    s3 = {
+      name       = "S3COLD"
+      endpoint   = "https://s3.amazonaws.com"
+      access_key = "AKIAIOSFODNN7EXAMPLE"
+      secret_key = "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY"
+      region     = "us-east-1"
+      bucket     = "cold-storage-backup"
+    }
+  })
+}
+```
+
+## Schema
+
+### Required
+
+- `name` (String) Tier name (must be uppercase). Changing this forces recreation.
+- `tier_type` (String) Tier type: s3, minio, azure, gcs, aliyun, tencent, huaweicloud, r2, or rustfs.
+- `config_json` (String, Sensitive) Backend-specific configuration as a JSON string.
+
+## Import
+
+Import is supported using the tier name:
+
+```
+terraform import rustfs_tier.example MYTIER
+```

--- a/examples/resources/rustfs_tier/resource.tf
+++ b/examples/resources/rustfs_tier/resource.tf
@@ -1,0 +1,14 @@
+resource "rustfs_tier" "s3_cold" {
+  name      = "S3COLD"
+  tier_type = "s3"
+  config_json = jsonencode({
+    s3 = {
+      name       = "S3COLD"
+      endpoint   = "https://s3.amazonaws.com"
+      access_key = "AKIAIOSFODNN7EXAMPLE"
+      secret_key = "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY"
+      region     = "us-east-1"
+      bucket     = "cold-storage-backup"
+    }
+  })
+}

--- a/pkg/rustfs/tier.go
+++ b/pkg/rustfs/tier.go
@@ -1,0 +1,53 @@
+package rustfs
+
+import (
+	"context"
+	"encoding/json"
+)
+
+func (c *RustfsAdmin) AddTier(config json.RawMessage) error {
+	reqData := RequestData{
+		Method:  "PUT",
+		RelPath: "tier",
+		Content: []byte(config),
+	}
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	resp, err := c.doRequest(ctx, reqData)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+	return nil
+}
+
+func (c *RustfsAdmin) EditTier(name string, config json.RawMessage) error {
+	reqData := RequestData{
+		Method:  "POST",
+		RelPath: "tier/" + name,
+		Content: []byte(config),
+	}
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	resp, err := c.doRequest(ctx, reqData)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+	return nil
+}
+
+func (c *RustfsAdmin) RemoveTier(name string) error {
+	reqData := RequestData{
+		Method:  "DELETE",
+		RelPath: "tier/" + name,
+	}
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	resp, err := c.doRequest(ctx, reqData)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+	return nil
+}

--- a/pkg/rustfs/tier_test.go
+++ b/pkg/rustfs/tier_test.go
@@ -1,0 +1,56 @@
+package rustfs
+
+import (
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func TestAddTier(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPut {
+			t.Errorf("expected PUT, got %s", r.Method)
+		}
+		body, _ := io.ReadAll(r.Body)
+		if !json.Valid(body) {
+			t.Errorf("expected valid JSON body, got %s", string(body))
+		}
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer server.Close()
+
+	client := New(&RustfsAdminConfig{
+		Endpoint:  server.Listener.Addr().String(),
+		AccessKey: "admin",
+	})
+	client.accessSecret = "secret"
+
+	config := json.RawMessage(`{"tier_type":"s3","s3":{"name":"MYTIER"}}`)
+	err := client.AddTier(config)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestRemoveTier(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodDelete {
+			t.Errorf("expected DELETE, got %s", r.Method)
+		}
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer server.Close()
+
+	client := New(&RustfsAdminConfig{
+		Endpoint:  server.Listener.Addr().String(),
+		AccessKey: "admin",
+	})
+	client.accessSecret = "secret"
+
+	err := client.RemoveTier("MYTIER")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}

--- a/provider/provider.go
+++ b/provider/provider.go
@@ -127,6 +127,7 @@ func (p *RustfsProvider) Resources(ctx context.Context) []func() resource.Resour
 		NewBucketRessource,
 		NewquotaRessource,
 		NewBucketLifecycleConfigurationRessource,
+		NewTierResource,
 		NewBucketObjectLockResource,
 	}
 }

--- a/provider/rustfs_tier_resource.go
+++ b/provider/rustfs_tier_resource.go
@@ -1,0 +1,136 @@
+package provider
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+
+	"github.com/hashicorp/terraform-plugin-framework/path"
+	"github.com/hashicorp/terraform-plugin-framework/resource"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+)
+
+var (
+	_ resource.Resource                = &TierResource{}
+	_ resource.ResourceWithImportState = &TierResource{}
+)
+
+type TierResource struct {
+	client *AllClient
+}
+
+type tierResourceModel struct {
+	Name       types.String `tfsdk:"name"`
+	TierType   types.String `tfsdk:"tier_type"`
+	ConfigJson types.String `tfsdk:"config_json"`
+}
+
+func NewTierResource() resource.Resource {
+	return &TierResource{}
+}
+
+func (r *TierResource) Metadata(_ context.Context, req resource.MetadataRequest, resp *resource.MetadataResponse) {
+	resp.TypeName = req.ProviderTypeName + "_tier"
+}
+
+func (r *TierResource) Schema(_ context.Context, _ resource.SchemaRequest, resp *resource.SchemaResponse) {
+	resp.Schema = schema.Schema{
+		Description:         "Manage RustFS storage tiers",
+		MarkdownDescription: "Manage RustFS storage tiers for data transition to external backends",
+		Attributes: map[string]schema.Attribute{
+			"name": schema.StringAttribute{
+				Required:    true,
+				Description: "Tier name (must be uppercase). Changing this forces recreation.",
+				PlanModifiers: []planmodifier.String{stringplanmodifier.RequiresReplace()},
+			},
+			"tier_type": schema.StringAttribute{
+				Required:    true,
+				Description: "Tier type: s3, minio, azure, gcs, aliyun, tencent, huaweicloud, r2, or rustfs.",
+				PlanModifiers: []planmodifier.String{stringplanmodifier.RequiresReplace()},
+			},
+			"config_json": schema.StringAttribute{
+				Required:    true,
+				Sensitive:   true,
+				Description: "Backend-specific configuration as a JSON string. See RustFS tier documentation for the expected format per backend type.",
+			},
+		},
+	}
+}
+
+func (r *TierResource) Configure(_ context.Context, req resource.ConfigureRequest, resp *resource.ConfigureResponse) {
+	if req.ProviderData == nil {
+		return
+	}
+	client, ok := req.ProviderData.(*AllClient)
+	if !ok {
+		resp.Diagnostics.AddError("Unexpected Resource Configure Type", fmt.Sprintf("Expected *AllClient, got: %T.", req.ProviderData))
+		return
+	}
+	r.client = client
+}
+
+func (r *TierResource) Create(ctx context.Context, req resource.CreateRequest, resp *resource.CreateResponse) {
+	var plan tierResourceModel
+	resp.Diagnostics.Append(req.Plan.Get(ctx, &plan)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	if !json.Valid([]byte(plan.ConfigJson.ValueString())) {
+		resp.Diagnostics.AddError("Invalid JSON", "config_json must be valid JSON")
+		return
+	}
+
+	if err := r.client.RustClient.AddTier(json.RawMessage(plan.ConfigJson.ValueString())); err != nil {
+		resp.Diagnostics.AddError("Error adding tier", "Could not add tier: "+err.Error())
+		return
+	}
+
+	resp.Diagnostics.Append(resp.State.Set(ctx, &plan)...)
+}
+
+func (r *TierResource) Read(ctx context.Context, req resource.ReadRequest, resp *resource.ReadResponse) {
+	var state tierResourceModel
+	resp.Diagnostics.Append(req.State.Get(ctx, &state)...)
+	resp.Diagnostics.Append(resp.State.Set(ctx, &state)...)
+}
+
+func (r *TierResource) Update(ctx context.Context, req resource.UpdateRequest, resp *resource.UpdateResponse) {
+	var plan tierResourceModel
+	resp.Diagnostics.Append(req.Plan.Get(ctx, &plan)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	if !json.Valid([]byte(plan.ConfigJson.ValueString())) {
+		resp.Diagnostics.AddError("Invalid JSON", "config_json must be valid JSON")
+		return
+	}
+
+	if err := r.client.RustClient.EditTier(plan.Name.ValueString(), json.RawMessage(plan.ConfigJson.ValueString())); err != nil {
+		resp.Diagnostics.AddError("Error editing tier", "Could not edit tier: "+err.Error())
+		return
+	}
+
+	resp.Diagnostics.Append(resp.State.Set(ctx, &plan)...)
+}
+
+func (r *TierResource) Delete(ctx context.Context, req resource.DeleteRequest, resp *resource.DeleteResponse) {
+	var data tierResourceModel
+	resp.Diagnostics.Append(req.State.Get(ctx, &data)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	if err := r.client.RustClient.RemoveTier(data.Name.ValueString()); err != nil {
+		resp.Diagnostics.AddError("Error removing tier", "Could not remove tier: "+err.Error())
+		return
+	}
+}
+
+func (r *TierResource) ImportState(ctx context.Context, req resource.ImportStateRequest, resp *resource.ImportStateResponse) {
+	resource.ImportStatePassthroughID(ctx, path.Root("name"), req, resp)
+}


### PR DESCRIPTION
Fixes #57

## Feature

`rustfs_tier` resource to manage storage tiers for data transition to external backends.

## Design

Uses a generic `config_json` field that accepts the raw JSON body expected by the RustFS Admin API. This avoids having to model every backend type (S3, Azure, GCS, MinIO, Aliyun, etc.) individually in the Terraform schema. Users compose the JSON using `jsonencode()`.

## Usage — S3 backend

```terraform
resource "rustfs_tier" "s3_cold" {
  name      = "S3COLD"
  tier_type = "s3"
  config_json = jsonencode({
    s3 = {
      name       = "S3COLD"
      endpoint   = "https://s3.amazonaws.com"
      access_key = "AKIA..."
      secret_key = "..."
      region     = "us-east-1"
      bucket     = "cold-storage-backup"
    }
  })
}
```

## API

- `PUT /v3/tier` — add tier
- `POST /v3/tier/{name}` — edit tier
- `DELETE /v3/tier/{name}` — remove tier

## Supported backends

s3, minio, azure, gcs, aliyun, tencent, huaweicloud, r2, rustfs