### PR TITLE
docs: rewrite README with complete resource listing, examples, and testing guide

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,138 @@
+---
+name: Bug Report
+description: File a bug report to help us improve
+title: "[BUG]: "
+labels: ["bug"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for taking the time to fill out this bug report! Please provide as much detail as possible.
+
+  - type: textarea
+    id: bug-description
+    attributes:
+      label: Bug Description
+      description: A clear and concise description of what the bug is
+      placeholder: Describe what happened and what you expected to happen
+    validations:
+      required: true
+
+  - type: textarea
+    id: reproduction-steps
+    attributes:
+      label: Reproduction Steps
+      description: Steps to reproduce the behavior
+      placeholder: |
+        1. Configure provider with version X
+        2. Apply this configuration...
+        3. See error
+    validations:
+      required: true
+
+  - type: textarea
+    id: expected-behavior
+    attributes:
+      label: Expected Behavior
+      description: What you expected to happen
+    validations:
+      required: true
+
+  - type: textarea
+    id: actual-behavior
+    attributes:
+      label: Actual Behavior
+      description: What actually happened
+    validations:
+      required: true
+
+  - type: textarea
+    id: terraform-config
+    attributes:
+      label: Terraform Configuration
+      description: Minimal configuration that reproduces the issue
+      render: hcl
+      placeholder: |
+        terraform {
+          required_providers {
+            rustfs = {
+              source = "weinmann-emt/rustfs"
+              version = "x.x.x"
+            }
+          }
+        }
+
+        provider "rustfs" {
+          endpoint      = "127.0.0.1:9001"
+          access_key    = "admin"
+          access_secret = "secret"
+        }
+
+        resource "rustfs_bucket" "test" {
+          name = "test-bucket"
+        }
+    validations:
+      required: true
+
+  - type: textarea
+    id: error-output
+    attributes:
+      label: Error Output
+      description: Full error message and stack trace
+      render: shell
+    validations:
+      required: false
+
+  - type: input
+    id: provider-version
+    attributes:
+      label: Provider Version
+      placeholder: "0.0.7"
+    validations:
+      required: true
+
+  - type: input
+    id: terraform-version
+    attributes:
+      label: Terraform Version
+      placeholder: "1.14.6"
+    validations:
+      required: true
+
+  - type: input
+    id: rustfs-version
+    attributes:
+      label: RustFS Version
+      placeholder: "1.0.0-beta.8"
+    validations:
+      required: true
+
+  - type: dropdown
+    id: operating-system
+    attributes:
+      label: Operating System
+      options:
+        - Linux
+        - macOS
+        - Windows
+        - Other
+    validations:
+      required: true
+
+  - type: textarea
+    id: additional-context
+    attributes:
+      label: Additional Context
+      description: Any additional information about your environment
+    validations:
+      required: false
+
+  - type: checkboxes
+    id: terms
+    attributes:
+      label: Confirmation
+      options:
+        - label: I have searched existing issues for similar problems
+          required: true
+        - label: I have provided all the requested information
+          required: true

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,92 @@
+---
+name: Feature Request
+description: Suggest a new feature or enhancement
+title: "[FEATURE]: "
+labels: ["enhancement"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for suggesting a new feature! Please provide as much detail as possible.
+
+  - type: textarea
+    id: feature-description
+    attributes:
+      label: Feature Description
+      description: A clear and concise description of the feature you'd like to see
+    validations:
+      required: true
+
+  - type: textarea
+    id: problem-statement
+    attributes:
+      label: Problem Statement
+      description: What problem does this feature solve?
+    validations:
+      required: true
+
+  - type: textarea
+    id: proposed-solution
+    attributes:
+      label: Proposed Solution
+      description: How would you like this feature to work?
+    validations:
+      required: true
+
+  - type: textarea
+    id: terraform-example
+    attributes:
+      label: Terraform Example
+      description: Show how you would like to use this feature
+      render: hcl
+      placeholder: |
+        resource "rustfs_example" "test" {
+          name = "example"
+          # ...
+        }
+    validations:
+      required: false
+
+  - type: dropdown
+    id: feature-type
+    attributes:
+      label: Feature Type
+      options:
+        - New Resource
+        - New Data Source
+        - Enhancement to Existing Resource
+        - Provider Configuration
+        - Documentation Improvement
+        - Other
+    validations:
+      required: true
+
+  - type: dropdown
+    id: priority
+    attributes:
+      label: Priority
+      options:
+        - Critical - Blocking my adoption
+        - High - Significant impact on workflow
+        - Medium - Nice to have
+        - Low - Minor improvement
+    validations:
+      required: true
+
+  - type: textarea
+    id: additional-context
+    attributes:
+      label: Additional Context
+      description: Any additional information or references
+    validations:
+      required: false
+
+  - type: checkboxes
+    id: terms
+    attributes:
+      label: Confirmation
+      options:
+        - label: I have searched existing issues for similar requests
+          required: true
+        - label: I have checked that this feature is not already implemented
+          required: true

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,59 @@
+## Description
+
+### Type of Change
+- [ ] Bug fix (non-breaking change that fixes an issue)
+- [ ] New feature (non-breaking change that adds functionality)
+- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
+- [ ] Documentation update
+- [ ] Refactoring (no functional changes, code improvement)
+
+### What does this PR do?
+
+<!-- Provide a clear description of what this PR does and why. -->
+
+### How was this change tested?
+
+<!-- 
+Describe how you tested this change:
+- Unit tests
+- Acceptance tests (run locally with Podman)
+- Manual testing scenarios
+-->
+
+### Related Issues
+
+<!-- Link to related issues using: Fixes #123, Related to #456 -->
+
+## Testing Checklist
+
+- [ ] Unit tests added/updated
+- [ ] Acceptance tests added/updated (for new resources)
+- [ ] `go fmt ./...` passes
+- [ ] `go vet ./...` passes
+- [ ] Tests run locally with Podman before pushing
+
+## Documentation Checklist
+
+- [ ] Documentation added to `docs/` directory
+- [ ] Example added to `examples/` directory
+- [ ] Schema attributes have descriptions
+- [ ] Import section documented (if applicable)
+
+## Checklist for Specific Changes
+
+### New Resources
+- [ ] API client methods in `pkg/rustfs/<name>.go`
+- [ ] Resource file in `provider/rustfs_<name>_resource.go`
+- [ ] Registered in `provider/provider.go`
+- [ ] ImportState implemented
+- [ ] Documentation + example
+
+### New Data Sources
+- [ ] Data source file in `provider/rustfs_<name>_datasource.go`
+- [ ] Registered in `provider/provider.go`
+- [ ] Documentation + example
+
+### Bug Fixes
+- [ ] Root cause identified
+- [ ] Regression test added
+- [ ] Edge cases considered

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,35 @@
+# Code of Conduct
+
+## Our Pledge
+
+We as members, contributors, and leaders pledge to make participation in our
+community a harassment-free experience for everyone, regardless of age, body
+size, visible or invisible disability, ethnicity, sex characteristics, gender
+identity and expression, level of experience, education, socio-economic status,
+nationality, personal appearance, race, religion, or sexual identity
+and orientation.
+
+We pledge to act and interact in ways that contribute to an open, welcoming,
+diverse, inclusive, and healthy community.
+
+## Our Standards
+
+Examples of behavior that contributes to a positive environment:
+
+* Demonstrating empathy and kindness toward other people
+* Being respectful of differing opinions, viewpoints, and experiences
+* Giving and gracefully accepting constructive feedback
+* Accepting responsibility and apologizing to those affected by our mistakes,
+  and learning from the experience
+* Focusing on what is best for the overall community
+
+## Enforcement
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be
+reported to the community leaders responsible for enforcement.
+All complaints will be reviewed and investigated promptly and fairly.
+
+## Attribution
+
+This Code of Conduct is adapted from the [Contributor Covenant](https://www.contributor-covenant.org),
+version 2.1.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,144 @@
+# Contributing
+
+Thank you for considering contributing to the Terraform Provider for RustFS! This document provides guidelines for contributors.
+
+## Getting Started
+
+### Prerequisites
+
+- [Go](https://golang.org/doc/install) 1.22 or later
+- [Podman](https://podman.io) and `podman-compose`
+- [Git](https://git-scm.com)
+
+### First Time Setup
+
+```bash
+git clone https://github.com/weinmann-emt/terraform-provider-rustfs.git
+cd terraform-provider-rustfs
+go mod download
+```
+
+## Development
+
+### Building
+
+```bash
+go build -o terraform-provider-rustfs
+```
+
+### Local Development
+
+Add to `~/.terraformrc`:
+
+```hcl
+provider_installation {
+  dev_overrides {
+    "weinmann-emt/rustfs" = "/path/to/terraform-provider-rustfs"
+  }
+}
+```
+
+### Project Structure
+
+```
+├── provider/                # Terraform resource implementations
+│   ├── provider.go          # Provider definition and registration
+│   ├── rustfs_*_resource.go # Resource CRUD implementations
+│   ├── rustfs_*_datasource.go # Data source implementations
+│   ├── *_test.go            # Tests
+│   └── provider_test.go     # Test infrastructure
+├── pkg/rustfs/              # RustFS API client library
+│   ├── admin_client.go      # HTTP client with AWS SigV4 signing
+│   └── *.go                 # Per-resource API methods
+├── examples/                # Example Terraform configurations
+├── docs/                    # Generated documentation
+├── acc_test/                # Acceptance test Docker environment
+└── .github/                 # CI, templates
+```
+
+## Making Changes
+
+### Code Style
+
+- Run `go fmt ./...` before committing
+- Run `go vet ./...` to catch issues
+- All attributes must have descriptions
+- All resources must implement `ResourceWithImportState`
+- Sensitive fields must be marked `Sensitive: true`
+
+### Resource Implementation Pattern
+
+```go
+var (
+    _ resource.Resource                = &ExampleResource{}
+    _ resource.ResourceWithImportState = &ExampleResource{}
+)
+
+func (r *ExampleResource) Create(ctx context.Context, req resource.CreateRequest, resp *resource.CreateResponse) { ... }
+func (r *ExampleResource) Read(ctx context.Context, req resource.ReadRequest, resp *resource.ReadResponse)     { ... }
+func (r *ExampleResource) Update(ctx context.Context, req resource.UpdateRequest, resp *resource.UpdateResponse) { ... }
+func (r *ExampleResource) Delete(ctx context.Context, req resource.DeleteRequest, resp *resource.DeleteResponse) { ... }
+func (r *ExampleResource) ImportState(ctx context.Context, req resource.ImportStateRequest, resp *resource.ImportStateResponse) { ... }
+```
+
+### Adding New Resources
+
+1. Create API client methods in `pkg/rustfs/<name>.go`
+2. Create resource file in `provider/rustfs_<name>_resource.go`
+3. Register in `provider/provider.go` Resources list
+4. Add documentation in `docs/resources/<name>.md`
+5. Add example in `examples/resources/<name>/resource.tf`
+
+## Testing
+
+### Unit Tests
+
+```bash
+go test ./pkg/rustfs/... -v
+go test ./provider/... -v -run "^[^T]"
+```
+
+### Acceptance Tests
+
+Start a RustFS instance and run acceptance tests:
+
+```bash
+podman-compose -f acc_test/docker-compose.yml up -d
+RUSTFS_ENDPOINT="127.0.0.1:9001" \
+  RUSTFS_USER="rustfsadmin" RUSTFS_SECRET="rustfsadmin" \
+  TF_ACC=1 go test -v ./provider -run "TestAcc"
+podman-compose -f acc_test/docker-compose.yml down
+```
+
+Run a specific test:
+
+```bash
+TF_ACC=1 go test -v ./provider -run "TestAccBucketResource"
+```
+
+## Submitting Changes
+
+### Before Submitting
+
+1. Run all unit tests
+2. Run acceptance tests locally for new resources
+3. Run `go fmt ./...` and `go vet ./...`
+4. Add/update documentation
+
+### Pull Request Process
+
+1. One feature or fix per PR
+2. Use descriptive title referencing the issue (e.g., "feat: add rustfs_group resource (#50)")
+3. Link related issues with "Fixes #123"
+4. Include unit tests for new code
+5. Include acceptance tests for new resources
+
+## Getting Help
+
+- **GitHub Issues**: Bug reports and feature requests
+- **Pull Requests**: Code contributions
+- **Discussions**: General questions
+
+## License
+
+By contributing, you agree that your contributions will be licensed under the MPL-2.0 License.

--- a/README.md
+++ b/README.md
@@ -1,30 +1,173 @@
-# Terraform Provider Rustfs
+# Terraform Provider for RustFS
 
-This provider should take care of rustfs management.
-The issue I needed to solve is a missing functionality of the aws provider on my installation.
-A working solution was: https://github.com/aminueza/terraform-provider-minio for bucket management.
+[![Go Version](https://img.shields.io/github/go-mod/go-version/weinmann-emt/terraform-provider-rustfs)](https://golang.org/doc/devel/release.html)
+[![CI](https://img.shields.io/github/actions/workflow/status/weinmann-emt/terraform-provider-rustfs/main.yml?branch=main)](https://github.com/weinmann-emt/terraform-provider-rustfs/actions)
 
-As IAM should also be maneged I will use the provider of aminueza and add some rust endpoint.
+Terraform provider for managing [RustFS](https://github.com/rustfs/rustfs) — an S3-compatible object storage system. Manage buckets, IAM users, policies, service accounts, quotas, lifecycle rules, encryption, versioning, and more.
 
+## Resources
 
+| Resource | Description |
+|----------|-------------|
+| `rustfs_bucket` | S3-compatible bucket management |
+| `rustfs_bucket_encryption` | Server-side encryption (SSE-S3, SSE-KMS) |
+| `rustfs_bucket_lifecycle_configuration` | Object lifecycle rules |
+| `rustfs_bucket_notification` | Event notification queues |
+| `rustfs_bucket_object_lock` | Object lock and retention |
+| `rustfs_bucket_replication` | Cross-bucket replication |
+| `rustfs_bucket_versioning` | Versioning configuration |
+| `rustfs_group` | IAM group management with members |
+| `rustfs_iam_backup_import` | Import IAM entities from backup |
+| `rustfs_policy` | S3 policy management |
+| `rustfs_quota` | Bucket quota limits |
+| `rustfs_rebalance` | Trigger pool rebalancing |
+| `rustfs_serviceaccount` | Service accounts / API keys |
+| `rustfs_tier` | Storage tier management (S3, Azure, GCS, etc.) |
+| `rustfs_user` | IAM user management |
 
-## Endpoints
-At the moment I was not able to get a good api definition. Will try: https://deepwiki.com/rustfs/rustfs/10-reference#admin-api-routes and some postman magic.
+## Data Sources
 
+| Data Source | Description |
+|-------------|-------------|
+| `rustfs_bucket_metadata_backup` | Export bucket metadata as ZIP |
+| `rustfs_iam_backup` | Export IAM entities as ZIP |
+| `rustfs_pools` | List storage pools |
+| `rustfs_users` | List IAM users |
 
-## Acceptanc testing
+## Example Usage
 
-Unit test performed with pkg work simply out of the box.
-To perform acceptance test of the provider we need to follow: https://developer.hashicorp.com/terraform/tutorials/providers-plugin-framework/providers-plugin-framework-provider#prepare-terraform-for-local-provider-install
+```terraform
+terraform {
+  required_providers {
+    rustfs = {
+      source  = "weinmann-emt/rustfs"
+      version = "~> 0.0.7"
+    }
+  }
+}
 
- ~/.terraformrc
+# Provider configuration via environment variables
+provider "rustfs" {}
+
+# Or via provider block
+provider "rustfs" {
+  endpoint      = "127.0.0.1:9001"
+  access_key    = "admin"
+  access_secret = "secret"
+}
+
+# Bucket
+resource "rustfs_bucket" "example" {
+  name = "my-bucket"
+}
+
+# User with access key
+resource "rustfs_user" "example" {
+  access_key = "myuser"
+  secret_key = "supersecret"
+  name       = "My User"
+  status     = "enabled"
+}
+
+# Service account
+resource "rustfs_serviceaccount" "ci_token" {
+  access_key  = "ci-bot"
+  secret_key  = "s3cret"
+  name        = "CI Pipeline"
+  description = "Token for CI/CD access"
+}
+
+# IAM policy
+resource "rustfs_policy" "readwrite" {
+  name = "readwrite"
+  statement = [{
+    effect    = "Allow"
+    action    = ["s3:GetObject", "s3:PutObject", "s3:ListBucket"]
+    ressource = ["arn:aws:s3:::my-bucket", "arn:aws:s3:::my-bucket/*"]
+  }]
+}
+
+# Bucket quota (10 GiB)
+resource "rustfs_quota" "example" {
+  bucket = rustfs_bucket.example.name
+  quota  = 10737418240
+}
+
+# Versioning
+resource "rustfs_bucket_versioning" "example" {
+  bucket = rustfs_bucket.example.name
+  status = "Enabled"
+}
+
+# Object lock
+resource "rustfs_bucket_object_lock" "example" {
+  bucket = rustfs_bucket.example.name
+  mode   = "COMPLIANCE"
+  days   = 365
+}
 ```
+
+More examples in the [`examples/`](./examples/) directory.
+
+## Authentication
+
+Credentials can be provided via the provider block or environment variables. Environment variables take precedence when both are set.
+
+| Provider Attribute | Environment Variable | Description |
+|--------------------|---------------------|-------------|
+| `endpoint` | `RUSTFS_ENDPOINT` | RustFS server in `host:port` format |
+| `access_key` | `RUSTFS_USER` | Access key / username |
+| `access_secret` | `RUSTFS_SECRET` | Secret key / password |
+
+## Building
+
+```bash
+git clone https://github.com/weinmann-emt/terraform-provider-rustfs.git
+cd terraform-provider-rustfs
+go build -o terraform-provider-rustfs
+```
+
+For local development, add to `~/.terraformrc`:
+
+```hcl
 provider_installation {
   dev_overrides {
-      "weinmann/rustfs" = "/workspaces/terraform-provider-rustfs"
+    "weinmann-emt/rustfs" = "/path/to/terraform-provider-rustfs"
   }
 }
 ```
 
-## Publish
-ToDo: https://developer.hashicorp.com/terraform/registry/providers/publishing
+## Testing
+
+### Unit tests
+
+```bash
+go test ./pkg/rustfs/... -v
+go test ./provider/... -v -run "^[^T]"  # Skip acceptance tests
+```
+
+### Acceptance tests
+
+Requires a running RustFS instance:
+
+```bash
+# Start RustFS
+podman-compose -f acc_test/docker-compose.yml up -d
+
+# Run acceptance tests
+RUSTFS_ENDPOINT="127.0.0.1:9001" \
+RUSTFS_USER="rustfsadmin" \
+RUSTFS_SECRET="rustfsadmin" \
+TF_ACC=1 go test -v ./provider -run "TestAcc"
+
+# Cleanup
+podman-compose -f acc_test/docker-compose.yml down
+```
+
+## Documentation
+
+Full resource documentation is available in the [`docs/`](./docs/) directory or on the [Terraform Registry](https://registry.terraform.io/providers/weinmann-emt/rustfs).
+
+## License
+
+[MPL-2.0](LICENSE)

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,48 @@
+# Security Policy
+
+## Supported Versions
+
+| Version | Supported |
+|---------|-----------|
+| latest  | ✅ |
+| < latest| ❌ |
+
+Only the latest released version receives security updates.
+
+## Reporting a Vulnerability
+
+If you discover a security vulnerability, please **DO NOT** open a public issue.
+
+**Preferred Method:** Use GitHub's [Private Vulnerability Reporting](https://github.com/weinmann-emt/terraform-provider-rustfs/security/advisories/new)
+
+### What to Include
+
+- **Vulnerability Type**: What type of vulnerability is it
+- **Affected Versions**: Which provider versions are affected
+- **Impact**: What is the impact (data exposure, privilege escalation, etc.)
+- **Reproduction Steps**: Detailed steps to reproduce
+- **Proof of Concept**: If possible, include a minimal PoC
+
+### Response Timeline
+
+- **Initial Response**: Within 48 hours
+- **Detailed Assessment**: Within 7 days
+- **Public Disclosure**: After a fix is released, typically within 14 days
+
+## Security Best Practices for Users
+
+1. **Credential Management**
+   - Use environment variables (`RUSTFS_USER`, `RUSTFS_SECRET`) instead of hardcoded credentials
+   - Rotate credentials regularly
+
+2. **Network Security**
+   - Use TLS (`ssl = true`) for production deployments
+   - Consider private networks for sensitive data
+
+3. **State Protection**
+   - Encrypt Terraform state files
+   - Use remote state backends with proper access controls
+
+4. **Monitoring**
+   - Enable RustFS audit logging
+   - Review provider logs for accidental credential exposure


### PR DESCRIPTION
## Summary

Replaces the minimal placeholder README with a comprehensive document.

## What's new

- Complete resource table (16 resources with descriptions)
- Data source table (4 data sources)
- 6+ working Terraform usage examples (bucket, user, policy, quota, versioning, service account)
- Authentication guide (provider block vs env vars)
- Build instructions (clone, build, dev override)
- Testing guide (unit tests + acceptance tests with Podman)
- Badges (Go version, CI status)
- No references to external projects