### PR TITLE
fix: resource block in statement of rustfs_policy resource is optional

### DIFF
--- a/docs/resources/policy.md
+++ b/docs/resources/policy.md
@@ -31,6 +31,9 @@ Required:
 
 - `action` (List of String)
 - `effect` (String)
+
+Optional:
+
 - `ressource` (List of String)
 
 ## Import

--- a/pkg/rustfs/policy.go
+++ b/pkg/rustfs/policy.go
@@ -11,7 +11,7 @@ import (
 type PolicyStatement struct {
 	Effect   string   `json:"Effect"`
 	Action   []string `json:"Action"`
-	Resource []string `json:"Resource"`
+	Resource []string `json:"Resource,omitempty"`
 }
 
 type PolicyStatementSinle struct {

--- a/provider/rustfs_policy_ressource.go
+++ b/provider/rustfs_policy_ressource.go
@@ -74,7 +74,7 @@ func (r *PolicyRessource) Schema(_ context.Context, _ resource.SchemaRequest, re
 						},
 						"ressource": schema.SetAttribute{
 							ElementType: types.StringType,
-							Required:    true,
+							Optional:    true,
 						},
 					},
 				},


### PR DESCRIPTION
## Description

### Type of Change
- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes, code improvement)

### What does this PR do?

Makes the "ressource" argument within the nested statement block of the `rustfs_policy` resource optional. This is necessary because the `sts:AssumeRole` action is only valid when no resource block is set.

### How was this change tested?

- The unit tests pass.
- The Acceptance tests pass.
- I installed the provider locally with `go install .` and then added an overwrite to my `~/.terraformrc` file. I then created and deleted a `sts:AssumeRole` policy in my RustFS test instance with terraform.

### Related Issues

closes #84  

## Testing Checklist

- [ ] Unit tests added/updated
- [ ] Acceptance tests added/updated (for new resources)
- [x] `go fmt ./...` passes (only changes things in files I didn't touch)
- [x] `go vet ./...` passes
- [x] Tests run locally with Podman before pushing

## Documentation Checklist

- [x] Documentation added to `docs/` directory
- [ ] Example added to `examples/` directory
- [ ] Schema attributes have descriptions
- [ ] Import section documented (if applicable)

## Checklist for Specific Changes

### Bug Fixes
- [x] Root cause identified
- [ ] Regression test added
- [ ] Edge cases considered
