### PR TITLE
feat: add rustfs_group_policy_attachment resource (#89)

### DIFF
--- a/docs/resources/group_policy_attachment.md
+++ b/docs/resources/group_policy_attachment.md
@@ -1,0 +1,37 @@
+---
+page_title: "rustfs_group_policy_attachment Resource - rustfs"
+description: |-
+  Attach a canned IAM policy to an IAM group
+---
+
+# rustfs_group_policy_attachment (Resource)
+
+Attach a canned IAM policy to an IAM group. The policy is detached when the resource is destroyed.
+
+## Example Usage
+
+```terraform
+resource "rustfs_group_policy_attachment" "developers_readwrite" {
+  group  = rustfs_group.developers.name
+  policy = "readwrite"
+}
+```
+
+## Schema
+
+### Required
+
+- `group` (String) Name of the IAM group. Changing this forces a new attachment.
+- `policy` (String) Name of the canned policy. Changing this forces a new attachment.
+
+### Read-Only
+
+- `id` (String) Composite identifier in the form `group/policy`.
+
+## Import
+
+Import is supported using the composite `<group>/<policy>` identifier:
+
+```
+terraform import rustfs_group_policy_attachment.test developers/readwrite
+```

--- a/examples/resources/rustfs_group_policy_attachment/resource.tf
+++ b/examples/resources/rustfs_group_policy_attachment/resource.tf
@@ -1,0 +1,4 @@
+resource "rustfs_group_policy_attachment" "developers_readwrite" {
+  group  = "developers"
+  policy = "readwrite"
+}

--- a/pkg/rustfs/group.go
+++ b/pkg/rustfs/group.go
@@ -10,13 +10,14 @@ type GroupInfo struct {
 	Name    string   `json:"name"`
 	Status  string   `json:"status"`
 	Members []string `json:"members"`
+	Policy  string   `json:"policy"`
 }
 
 type GroupAddRemove struct {
 	Group    string   `json:"group"`
 	Members  []string `json:"members"`
-	IsRemove bool     `json:"is_remove"`
-	Status   string   `json:"status"`
+	IsRemove bool     `json:"isRemove"`
+	Status   string   `json:"groupStatus"`
 }
 
 func (c *RustfsAdmin) GetGroup(name string) (GroupInfo, error) {
@@ -40,6 +41,9 @@ func (c *RustfsAdmin) GetGroup(name string) (GroupInfo, error) {
 }
 
 func (c *RustfsAdmin) UpdateGroupMembers(req GroupAddRemove) error {
+	if req.Members == nil {
+		req.Members = []string{}
+	}
 	bytes, err := json.Marshal(req)
 	if err != nil {
 		return err

--- a/pkg/rustfs/group_policy_attachment.go
+++ b/pkg/rustfs/group_policy_attachment.go
@@ -1,0 +1,42 @@
+package rustfs
+
+import (
+	"context"
+	"net/url"
+)
+
+// AttachGroupPolicy attaches a canned policy to an IAM group.
+func (c *RustfsAdmin) AttachGroupPolicy(group, policy string) error {
+	query := url.Values{}
+	query.Set("userOrGroup", group)
+	query.Set("policyName", policy)
+	query.Set("isGroup", "true")
+	reqData := RequestData{
+		Method:      "PUT",
+		RelPath:     "set-user-or-group-policy",
+		QueryValues: query,
+	}
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	_, err := c.doRequest(ctx, reqData)
+	return err
+}
+
+// DetachGroupPolicy detaches a canned policy from an IAM group. The admin API
+// exposes no DELETE on set-user-or-group-policy; an empty policyName removes
+// the policy mapping (same semantics as MinIO set-policy with an empty name).
+func (c *RustfsAdmin) DetachGroupPolicy(group, policy string) error {
+	query := url.Values{}
+	query.Set("userOrGroup", group)
+	query.Set("policyName", "")
+	query.Set("isGroup", "true")
+	reqData := RequestData{
+		Method:      "PUT",
+		RelPath:     "set-user-or-group-policy",
+		QueryValues: query,
+	}
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	_, err := c.doRequest(ctx, reqData)
+	return err
+}

--- a/pkg/rustfs/group_policy_attachment_test.go
+++ b/pkg/rustfs/group_policy_attachment_test.go
@@ -1,0 +1,88 @@
+package rustfs
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"strings"
+	"testing"
+)
+
+func TestAttachGroupPolicyAttachment(t *testing.T) {
+	var gotMethod string
+	var gotQuery url.Values
+	var gotPath string
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotMethod = r.Method
+		gotQuery = r.URL.Query()
+		gotPath = r.URL.Path + "?" + r.URL.RawQuery
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer server.Close()
+
+	client := New(&RustfsAdminConfig{
+		Endpoint:  server.Listener.Addr().String(),
+		AccessKey: "admin",
+	})
+	client.accessSecret = "secret"
+
+	if err := client.AttachGroupPolicy("developers", "readwrite"); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if gotMethod != "PUT" {
+		t.Errorf("expected PUT, got %s", gotMethod)
+	}
+	if !strings.Contains(gotPath, "/set-user-or-group-policy") {
+		t.Errorf("wrong path: %s", gotPath)
+	}
+	if gotQuery.Get("userOrGroup") != "developers" {
+		t.Errorf("expected userOrGroup=developers, got %s", gotQuery.Get("userOrGroup"))
+	}
+	if gotQuery.Get("policyName") != "readwrite" {
+		t.Errorf("expected policyName=readwrite, got %s", gotQuery.Get("policyName"))
+	}
+	if gotQuery.Get("isGroup") != "true" {
+		t.Errorf("expected isGroup=true, got %s", gotQuery.Get("isGroup"))
+	}
+}
+
+func TestDetachGroupPolicyAttachment(t *testing.T) {
+	var gotMethod string
+	var gotQuery url.Values
+	var gotPath string
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotMethod = r.Method
+		gotQuery = r.URL.Query()
+		gotPath = r.URL.Path + "?" + r.URL.RawQuery
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer server.Close()
+
+	client := New(&RustfsAdminConfig{
+		Endpoint:  server.Listener.Addr().String(),
+		AccessKey: "admin",
+	})
+	client.accessSecret = "secret"
+
+	if err := client.DetachGroupPolicy("developers", "readwrite"); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if gotMethod != "PUT" {
+		t.Errorf("expected PUT, got %s", gotMethod)
+	}
+	if !strings.Contains(gotPath, "/set-user-or-group-policy") {
+		t.Errorf("wrong path: %s", gotPath)
+	}
+	if gotQuery.Get("userOrGroup") != "developers" {
+		t.Errorf("expected userOrGroup=developers, got %s", gotQuery.Get("userOrGroup"))
+	}
+	if _, ok := gotQuery["policyName"]; !ok {
+		t.Error("expected policyName key in query")
+	}
+	if gotQuery.Get("policyName") != "" {
+		t.Errorf("expected empty policyName for detach, got %s", gotQuery.Get("policyName"))
+	}
+	if gotQuery.Get("isGroup") != "true" {
+		t.Errorf("expected isGroup=true, got %s", gotQuery.Get("isGroup"))
+	}
+}

--- a/provider/provider.go
+++ b/provider/provider.go
@@ -129,6 +129,7 @@ func (p *RustfsProvider) Resources(ctx context.Context) []func() resource.Resour
 		NewIamBackupImportResource,
 		NewBucketMetadataBackupImportResource,
 		NewGroupResource,
+		NewGroupPolicyAttachmentRessource,
 		NewBucketLifecycleConfigurationRessource,
 		NewTierResource,
 		NewBucketObjectLockResource,

--- a/provider/rustfs_group_policy_attachment_ressource.go
+++ b/provider/rustfs_group_policy_attachment_ressource.go
@@ -1,0 +1,163 @@
+package provider
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/hashicorp/terraform-plugin-framework/path"
+	"github.com/hashicorp/terraform-plugin-framework/resource"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/hashicorp/terraform-plugin-log/tflog"
+)
+
+var (
+	_ resource.Resource                = &GroupPolicyAttachmentRessource{}
+	_ resource.ResourceWithImportState = &GroupPolicyAttachmentRessource{}
+)
+
+type GroupPolicyAttachmentRessource struct {
+	client *AllClient
+}
+
+type GroupPolicyAttachmentRessourceModel struct {
+	Group  types.String `tfsdk:"group"`
+	Policy types.String `tfsdk:"policy"`
+	ID     types.String `tfsdk:"id"`
+}
+
+func NewGroupPolicyAttachmentRessource() resource.Resource {
+	return &GroupPolicyAttachmentRessource{}
+}
+
+func (r *GroupPolicyAttachmentRessource) Metadata(_ context.Context, req resource.MetadataRequest, resp *resource.MetadataResponse) {
+	resp.TypeName = req.ProviderTypeName + "_group_policy_attachment"
+}
+
+func (r *GroupPolicyAttachmentRessource) Schema(_ context.Context, _ resource.SchemaRequest, resp *resource.SchemaResponse) {
+	resp.Schema = schema.Schema{
+		Description:         "Attach a canned IAM policy to an IAM group",
+		MarkdownDescription: "Attach a canned IAM policy to an IAM group and detach it on destroy",
+		Attributes: map[string]schema.Attribute{
+			"group": schema.StringAttribute{
+				Required:    true,
+				Description: "Name of the IAM group. Changing this forces a new attachment.",
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.RequiresReplace(),
+				},
+			},
+			"policy": schema.StringAttribute{
+				Required:    true,
+				Description: "Name of the canned policy. Changing this forces a new attachment.",
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.RequiresReplace(),
+				},
+			},
+			"id": schema.StringAttribute{
+				Computed:    true,
+				Description: "Composite identifier in the form group/policy.",
+			},
+		},
+	}
+}
+
+func (r *GroupPolicyAttachmentRessource) Configure(_ context.Context, req resource.ConfigureRequest, resp *resource.ConfigureResponse) {
+	if req.ProviderData == nil {
+		return
+	}
+	client, ok := req.ProviderData.(*AllClient)
+	if !ok {
+		resp.Diagnostics.AddError(
+			"Unexpected Resource Configure Type",
+			fmt.Sprintf("Expected *AllClient, got: %T. Please report this issue to the provider developers.", req.ProviderData),
+		)
+		return
+	}
+	r.client = client
+}
+
+func (r *GroupPolicyAttachmentRessource) Create(ctx context.Context, req resource.CreateRequest, resp *resource.CreateResponse) {
+	var plan GroupPolicyAttachmentRessourceModel
+	resp.Diagnostics.Append(req.Plan.Get(ctx, &plan)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	err := r.client.RustClient.AttachGroupPolicy(plan.Group.ValueString(), plan.Policy.ValueString())
+	if err != nil {
+		resp.Diagnostics.AddError(
+			"Error attaching policy to group",
+			"Could not attach policy: "+err.Error(),
+		)
+		return
+	}
+
+	plan.ID = types.StringValue(plan.Group.ValueString() + "/" + plan.Policy.ValueString())
+	tflog.Trace(ctx, "attached policy to group")
+	resp.Diagnostics.Append(resp.State.Set(ctx, &plan)...)
+}
+
+func (r *GroupPolicyAttachmentRessource) Read(ctx context.Context, req resource.ReadRequest, resp *resource.ReadResponse) {
+	var state GroupPolicyAttachmentRessourceModel
+	resp.Diagnostics.Append(req.State.Get(ctx, &state)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+	// The API exposes no read-back for group policy attachments; the attach
+	// operation is idempotent and the natural key is immutable, so the last
+	// known state is preserved (same pattern as rustfs_bucket).
+	resp.Diagnostics.Append(resp.State.Set(ctx, &state)...)
+}
+
+func (r *GroupPolicyAttachmentRessource) Update(ctx context.Context, req resource.UpdateRequest, resp *resource.UpdateResponse) {
+	var plan GroupPolicyAttachmentRessourceModel
+	resp.Diagnostics.Append(req.Plan.Get(ctx, &plan)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+	// All attributes are RequiresReplace, so Terraform normally plans a
+	// replacement; re-attaching keeps this method correct if it is invoked.
+	err := r.client.RustClient.AttachGroupPolicy(plan.Group.ValueString(), plan.Policy.ValueString())
+	if err != nil {
+		resp.Diagnostics.AddError(
+			"Error attaching policy to group",
+			"Could not attach policy: "+err.Error(),
+		)
+		return
+	}
+	plan.ID = types.StringValue(plan.Group.ValueString() + "/" + plan.Policy.ValueString())
+	resp.Diagnostics.Append(resp.State.Set(ctx, &plan)...)
+}
+
+func (r *GroupPolicyAttachmentRessource) Delete(ctx context.Context, req resource.DeleteRequest, resp *resource.DeleteResponse) {
+	var data GroupPolicyAttachmentRessourceModel
+	resp.Diagnostics.Append(req.State.Get(ctx, &data)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	err := r.client.RustClient.DetachGroupPolicy(data.Group.ValueString(), data.Policy.ValueString())
+	if err != nil {
+		resp.Diagnostics.AddError(
+			"Error detaching policy from group",
+			"Could not detach policy: "+err.Error(),
+		)
+		return
+	}
+}
+
+func (r *GroupPolicyAttachmentRessource) ImportState(ctx context.Context, req resource.ImportStateRequest, resp *resource.ImportStateResponse) {
+	parts := strings.Split(req.ID, "/")
+	if len(parts) != 2 || parts[0] == "" || parts[1] == "" {
+		resp.Diagnostics.AddError(
+			"Invalid import ID",
+			"Expected format: <group>/<policy>",
+		)
+		return
+	}
+	resp.Diagnostics.Append(resp.State.SetAttribute(ctx, path.Root("group"), parts[0])...)
+	resp.Diagnostics.Append(resp.State.SetAttribute(ctx, path.Root("policy"), parts[1])...)
+}

--- a/provider/rustfs_group_policy_attachment_ressource.go
+++ b/provider/rustfs_group_policy_attachment_ressource.go
@@ -160,4 +160,5 @@ func (r *GroupPolicyAttachmentRessource) ImportState(ctx context.Context, req re
 	}
 	resp.Diagnostics.Append(resp.State.SetAttribute(ctx, path.Root("group"), parts[0])...)
 	resp.Diagnostics.Append(resp.State.SetAttribute(ctx, path.Root("policy"), parts[1])...)
+	resp.Diagnostics.Append(resp.State.SetAttribute(ctx, path.Root("id"), req.ID)...)
 }

--- a/provider/rustfs_group_policy_attachment_ressource_test.go
+++ b/provider/rustfs_group_policy_attachment_ressource_test.go
@@ -59,15 +59,25 @@ resource "rustfs_group_policy_attachment" "test" {
 `, groupName, policyName, groupName)
 }
 
-// The admin API exposes no read-back for group policy attachments, so
-// destruction is verified against the Terraform state only.
+// The admin API exposes no dedicated read-back for group policy attachments, so
+// destruction is verified against the group's own policy mapping: after the
+// attachment is removed the group must either be gone or carry no policy.
 func testAccCheckGroupPolicyAttachmentDestroy(s *terraform.State) error {
+	client := testAccRustClient()
 	for _, rs := range s.RootModule().Resources {
 		if rs.Type != "rustfs_group_policy_attachment" {
 			continue
 		}
-		if rs.Primary.ID != "" {
-			return fmt.Errorf("attachment %s still in state", rs.Primary.ID)
+		group := rs.Primary.Attributes["group"]
+		if group == "" {
+			continue
+		}
+		info, err := client.GetGroup(group)
+		if err != nil {
+			continue
+		}
+		if info.Policy != "" {
+			return fmt.Errorf("group %s still has policy %q attached", group, info.Policy)
 		}
 	}
 	return nil

--- a/provider/rustfs_group_policy_attachment_ressource_test.go
+++ b/provider/rustfs_group_policy_attachment_ressource_test.go
@@ -1,0 +1,74 @@
+package provider
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-testing/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/terraform"
+)
+
+func TestAccGroupPolicyAttachmentResource_basic(t *testing.T) {
+	groupName := fmt.Sprintf("tf-test-group-%d", acctest.RandInt())
+	policyName := fmt.Sprintf("tf-test-policy-%d", acctest.RandInt())
+	resourceName := "rustfs_group_policy_attachment.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		CheckDestroy:             testAccCheckGroupPolicyAttachmentDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccGroupPolicyAttachmentConfig(groupName, policyName),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceName, "group", groupName),
+					resource.TestCheckResourceAttr(resourceName, "policy", policyName),
+					resource.TestCheckResourceAttr(resourceName, "id", groupName+"/"+policyName),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateId:     groupName + "/" + policyName,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func testAccGroupPolicyAttachmentConfig(groupName, policyName string) string {
+	return testAccProviderConfig() + fmt.Sprintf(`
+resource "rustfs_group" "test" {
+  name = "%s"
+}
+
+resource "rustfs_policy" "test" {
+  name = "%s"
+  statement = [{
+    effect    = "Allow"
+    action    = ["s3:GetObject"]
+    ressource = ["arn:aws:s3:::%s/*"]
+  }]
+}
+
+resource "rustfs_group_policy_attachment" "test" {
+  group  = rustfs_group.test.name
+  policy = rustfs_policy.test.name
+}
+`, groupName, policyName, groupName)
+}
+
+// The admin API exposes no read-back for group policy attachments, so
+// destruction is verified against the Terraform state only.
+func testAccCheckGroupPolicyAttachmentDestroy(s *terraform.State) error {
+	for _, rs := range s.RootModule().Resources {
+		if rs.Type != "rustfs_group_policy_attachment" {
+			continue
+		}
+		if rs.Primary.ID != "" {
+			return fmt.Errorf("attachment %s still in state", rs.Primary.ID)
+		}
+	}
+	return nil
+}

--- a/provider/rustfs_group_resource.go
+++ b/provider/rustfs_group_resource.go
@@ -8,6 +8,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringdefault"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-plugin-log/tflog"
@@ -53,10 +54,12 @@ func (r *GroupResource) Schema(_ context.Context, _ resource.SchemaRequest, resp
 				Optional:    true,
 				Computed:    true,
 				Description: "Group status: enabled or disabled. Defaults to enabled.",
+				Default:     stringdefault.StaticString("enabled"),
 			},
 			"members": schema.SetAttribute{
 				ElementType: types.StringType,
 				Optional:    true,
+				Computed:    true,
 				Description: "Set of user access keys that are members of this group.",
 			},
 		},
@@ -86,9 +89,11 @@ func (r *GroupResource) Create(ctx context.Context, req resource.CreateRequest, 
 	}
 
 	var members []string
-	resp.Diagnostics.Append(plan.Members.ElementsAs(ctx, &members, false)...)
-	if resp.Diagnostics.HasError() {
-		return
+	if !plan.Members.IsUnknown() && !plan.Members.IsNull() {
+		resp.Diagnostics.Append(plan.Members.ElementsAs(ctx, &members, false)...)
+		if resp.Diagnostics.HasError() {
+			return
+		}
 	}
 
 	status := plan.Status.ValueString()
@@ -96,20 +101,20 @@ func (r *GroupResource) Create(ctx context.Context, req resource.CreateRequest, 
 		status = "enabled"
 	}
 
-	if len(members) > 0 {
-		err := r.client.RustClient.UpdateGroupMembers(rustfs.GroupAddRemove{
-			Group:    plan.Name.ValueString(),
-			Members:  members,
-			IsRemove: false,
-			Status:   status,
-		})
-		if err != nil {
-			resp.Diagnostics.AddError(
-				"Error creating group",
-				"Could not create group: "+err.Error(),
-			)
-			return
-		}
+	// The admin API creates a group implicitly via update-group-members, so it
+	// must always be called (even with zero members) to make the group exist.
+	err := r.client.RustClient.UpdateGroupMembers(rustfs.GroupAddRemove{
+		Group:    plan.Name.ValueString(),
+		Members:  members,
+		IsRemove: false,
+		Status:   status,
+	})
+	if err != nil {
+		resp.Diagnostics.AddError(
+			"Error creating group",
+			"Could not create group: "+err.Error(),
+		)
+		return
 	}
 
 	if status != "enabled" {
@@ -122,6 +127,12 @@ func (r *GroupResource) Create(ctx context.Context, req resource.CreateRequest, 
 		}
 	}
 
+	membersValue, diags := types.SetValueFrom(ctx, types.StringType, members)
+	resp.Diagnostics.Append(diags...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+	plan.Members = membersValue
 	plan.Status = types.StringValue(status)
 	tflog.Trace(ctx, "created group resource")
 	resp.Diagnostics.Append(resp.State.Set(ctx, &plan)...)


### PR DESCRIPTION
**Issue:** https://github.com/weinmann-emt/terraform-provider-rustfs/issues/89

Add `rustfs_group_policy_attachment` resource to attach a canned IAM policy to an IAM group.

Closes #89

## Changes
- `pkg/rustfs/policy_attachment.go`: attach/detach for groups (`PUT set-user-or-group-policy`, `isGroup=true`; detach via empty `policyName`).
- `provider/rustfs_group_policy_attachment_ressource.go`: CRUD + import (`group/policy`).
- Registered in `provider.go Resources()`; unit + acceptance tests; docs + example.

## Testing
- `go build ./...`, `go vet ./...` pass; httptest unit tests pass; `TestAccGroupPolicyAttachmentResource_basic` passes against a live RustFS.
- golangci-lint: no new findings; gofmt clean.

## Note
Includes a fix to the pre-existing `rustfs_group` resource (JSON field names `groupStatus`/`isRemove` + empty-group creation) — the attachment test cannot pass without the group resource working.
