### PR TITLE
feat: add rustfs_user_policy_attachment resource (#90)

### DIFF
--- a/docs/resources/user_policy_attachment.md
+++ b/docs/resources/user_policy_attachment.md
@@ -1,0 +1,56 @@
+---
+page_title: "rustfs_user_policy_attachment Resource - rustfs"
+description: |-
+  Attach a canned IAM policy to a user
+---
+
+# rustfs_user_policy_attachment (Resource)
+
+Attach a canned IAM policy to a user. The policy is detached when the resource is destroyed.
+
+RustFS stores the policies of a user as a list, so a user can hold more than one policy. This
+resource appends a single policy to that list on create and removes it on destroy, leaving any
+other attached policies untouched.
+
+## Interaction with rustfs_user.policy
+
+`rustfs_user.policy` manages the user's primary policy. It is applied through the
+`set-user-or-group-policy` endpoint, which **replaces** the whole policy mapping, so a user only
+holds the single primary policy via that attribute.
+
+`rustfs_user_policy_attachment` adds additional policies on top by calling the builtin-policy
+attach/detach endpoints (`POST idp/builtin/policy/attach` and `POST idp/builtin/policy/detach`),
+which append/remove a single policy without touching the rest.
+
+The two resources are independent: removing an attachment never touches `rustfs_user.policy` and
+vice versa. Changing `rustfs_user.policy` replaces the user, which also removes all its
+attachments. Recommended usage: keep the first policy in `rustfs_user.policy` and express every
+additional policy as an attachment (or model all policies as attachments).
+
+## Example Usage
+
+```terraform
+resource "rustfs_user_policy_attachment" "alice_readwrite" {
+  user   = rustfs_user.alice.access_key
+  policy = "readwrite"
+}
+```
+
+## Schema
+
+### Required
+
+- `policy` (String) Name of the canned policy. Changing this forces a new attachment.
+- `user` (String) Access key of the IAM user. Changing this forces a new attachment.
+
+### Read-Only
+
+- `id` (String) Composite identifier in the form `user/policy`.
+
+## Import
+
+Import is supported using the composite `<user>/<policy>` identifier:
+
+```
+terraform import rustfs_user_policy_attachment.test alice/readwrite
+```

--- a/examples/resources/rustfs_user_policy_attachment/resource.tf
+++ b/examples/resources/rustfs_user_policy_attachment/resource.tf
@@ -1,0 +1,10 @@
+resource "rustfs_user" "alice" {
+  access_key = "alice"
+  secret_key = "superSecret123!"
+  policy     = "readonly"
+}
+
+resource "rustfs_user_policy_attachment" "alice_readwrite" {
+  user   = rustfs_user.alice.access_key
+  policy = "readwrite"
+}

--- a/pkg/rustfs/admin_client_test.go
+++ b/pkg/rustfs/admin_client_test.go
@@ -1,11 +1,28 @@
 package rustfs_test
 
 import (
+	"net/http"
+	"net/http/httptest"
 	"os"
+	"strings"
 	"testing"
 
 	"github.com/weinmann-emt/terraform-provider-rustfs/pkg/rustfs"
 )
+
+// newTestAdminServer spins up an httptest server speaking the RustFS admin
+// API and returns a RustfsAdmin client pointed at it.
+func newTestAdminServer(t *testing.T, handler http.HandlerFunc) *rustfs.RustfsAdmin {
+	t.Helper()
+	srv := httptest.NewServer(handler)
+	t.Cleanup(srv.Close)
+	c := rustfs.New(&rustfs.RustfsAdminConfig{
+		AccessKey:    "admin",
+		AccessSecret: "secret",
+		Endpoint:     strings.TrimPrefix(srv.URL, "http://"),
+	})
+	return &c
+}
 
 func TestIsAdmin(t *testing.T) {
 	endpoint := os.Getenv("RUSTFS_ENDPOINT")

--- a/pkg/rustfs/user_policy_attachment.go
+++ b/pkg/rustfs/user_policy_attachment.go
@@ -1,0 +1,52 @@
+package rustfs
+
+import (
+	"context"
+	"encoding/json"
+)
+
+// userPolicyAssociationRequest is the JSON body accepted by the RustFS
+// builtin-policy attach/detach endpoints. Exactly one of User or Group must
+// be set, together with at least one policy name.
+type userPolicyAssociationRequest struct {
+	User     string   `json:"user,omitempty"`
+	Group    string   `json:"group,omitempty"`
+	Policies []string `json:"policies"`
+}
+
+// AttachUserPolicy attaches a canned policy to a user, leaving any policies
+// the user already holds untouched. RustFS stores a user's policies as a
+// comma-separated list, so this appends to the existing list instead of
+// replacing it (unlike PUT set-user-or-group-policy, which replaces the
+// whole mapping and is used for the single primary policy on rustfs_user).
+func (c *RustfsAdmin) AttachUserPolicy(user, policy string) error {
+	return c.userPolicyAssociation(user, policy, "idp/builtin/policy/attach")
+}
+
+// DetachUserPolicy detaches a single canned policy from a user, leaving any
+// other attached policies untouched. The RustFS admin API exposes no DELETE
+// variant of set-user-or-group-policy, so removal goes through the dedicated
+// POST idp/builtin/policy/detach endpoint.
+func (c *RustfsAdmin) DetachUserPolicy(user, policy string) error {
+	return c.userPolicyAssociation(user, policy, "idp/builtin/policy/detach")
+}
+
+func (c *RustfsAdmin) userPolicyAssociation(user, policy, relPath string) error {
+	body, err := json.Marshal(userPolicyAssociationRequest{
+		User:     user,
+		Policies: []string{policy},
+	})
+	if err != nil {
+		return err
+	}
+
+	reqData := RequestData{
+		Method:  "POST",
+		RelPath: relPath,
+		Content: body,
+	}
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	_, err = c.doRequest(ctx, reqData)
+	return err
+}

--- a/pkg/rustfs/user_policy_attachment_test.go
+++ b/pkg/rustfs/user_policy_attachment_test.go
@@ -1,0 +1,70 @@
+package rustfs_test
+
+import (
+	"io"
+	"net/http"
+	"strings"
+	"testing"
+)
+
+func TestUserPolicyAttachmentAttach(t *testing.T) {
+	var gotMethod, gotPath string
+	var gotBody []byte
+	client := newTestAdminServer(t, func(w http.ResponseWriter, r *http.Request) {
+		gotMethod = r.Method
+		gotPath = r.URL.Path
+		gotBody, _ = io.ReadAll(r.Body)
+		w.WriteHeader(http.StatusOK)
+	})
+
+	if err := client.AttachUserPolicy("alice", "readonly"); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if gotMethod != "POST" {
+		t.Errorf("expected POST, got %s", gotMethod)
+	}
+	if !strings.Contains(gotPath, "/idp/builtin/policy/attach") {
+		t.Errorf("wrong request path: %s", gotPath)
+	}
+	body := string(gotBody)
+	if !strings.Contains(body, `"user":"alice"`) || !strings.Contains(body, `"readonly"`) {
+		t.Errorf("wrong request body: %s", body)
+	}
+}
+
+func TestUserPolicyAttachmentDetach(t *testing.T) {
+	var gotMethod, gotPath string
+	var gotBody []byte
+	client := newTestAdminServer(t, func(w http.ResponseWriter, r *http.Request) {
+		gotMethod = r.Method
+		gotPath = r.URL.Path
+		gotBody, _ = io.ReadAll(r.Body)
+		w.WriteHeader(http.StatusOK)
+	})
+
+	if err := client.DetachUserPolicy("alice", "readonly"); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if gotMethod != "POST" {
+		t.Errorf("expected POST, got %s", gotMethod)
+	}
+	if !strings.Contains(gotPath, "/idp/builtin/policy/detach") {
+		t.Errorf("wrong request path: %s", gotPath)
+	}
+	body := string(gotBody)
+	if !strings.Contains(body, `"user":"alice"`) || !strings.Contains(body, `"readonly"`) {
+		t.Errorf("wrong request body: %s", body)
+	}
+}
+
+func TestUserPolicyAttachmentError(t *testing.T) {
+	client := newTestAdminServer(t, func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusBadRequest)
+	})
+
+	if err := client.AttachUserPolicy("alice", "readonly"); err == nil {
+		t.Fatal("expected error for non-2xx response, got nil")
+	}
+}

--- a/provider/provider.go
+++ b/provider/provider.go
@@ -123,6 +123,7 @@ func (p *RustfsProvider) Resources(ctx context.Context) []func() resource.Resour
 	return []func() resource.Resource{
 		NewUserRessource,
 		NewPolicyRessource,
+		NewUserPolicyAttachmentRessource,
 		NewServiceAccountRessource,
 		NewBucketRessource,
 		NewquotaRessource,

--- a/provider/rustfs_user_policy_attachment_ressource.go
+++ b/provider/rustfs_user_policy_attachment_ressource.go
@@ -1,0 +1,182 @@
+package provider
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/hashicorp/terraform-plugin-framework/path"
+	"github.com/hashicorp/terraform-plugin-framework/resource"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/hashicorp/terraform-plugin-log/tflog"
+)
+
+// Ensure the implementation satisfies the expected interfaces.
+var (
+	_ resource.Resource                = &UserPolicyAttachmentRessource{}
+	_ resource.ResourceWithImportState = &UserPolicyAttachmentRessource{}
+)
+
+// UserPolicyAttachmentRessource attaches one canned IAM policy to a user on
+// top of the user's primary policy, so a user can hold more than one policy.
+type UserPolicyAttachmentRessource struct {
+	client *AllClient
+}
+
+type UserPolicyAttachmentRessourceModel struct {
+	User   types.String `tfsdk:"user"`
+	Policy types.String `tfsdk:"policy"`
+	ID     types.String `tfsdk:"id"`
+}
+
+// NewUserPolicyAttachmentRessource is a helper function to simplify the provider implementation.
+func NewUserPolicyAttachmentRessource() resource.Resource {
+	return &UserPolicyAttachmentRessource{}
+}
+
+// Metadata returns the resource type name.
+func (r *UserPolicyAttachmentRessource) Metadata(_ context.Context, req resource.MetadataRequest, resp *resource.MetadataResponse) {
+	resp.TypeName = req.ProviderTypeName + "_user_policy_attachment"
+}
+
+// Schema defines the schema for the resource.
+func (r *UserPolicyAttachmentRessource) Schema(_ context.Context, _ resource.SchemaRequest, resp *resource.SchemaResponse) {
+	resp.Schema = schema.Schema{
+		Description:         "Attach a canned IAM policy to a user",
+		MarkdownDescription: "Attach a canned IAM policy to a user and detach it on destroy",
+		Attributes: map[string]schema.Attribute{
+			"user": schema.StringAttribute{
+				Required:    true,
+				Description: "Access key of the IAM user. Changing this forces a new attachment.",
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.RequiresReplace(),
+				},
+			},
+			"policy": schema.StringAttribute{
+				Required:    true,
+				Description: "Name of the canned policy. Changing this forces a new attachment.",
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.RequiresReplace(),
+				},
+			},
+			"id": schema.StringAttribute{
+				Computed:    true,
+				Description: "Composite identifier in the form user/policy.",
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.UseStateForUnknown(),
+				},
+			},
+		},
+	}
+}
+
+func (r *UserPolicyAttachmentRessource) Configure(_ context.Context, req resource.ConfigureRequest, resp *resource.ConfigureResponse) {
+	if req.ProviderData == nil {
+		return
+	}
+	client, ok := req.ProviderData.(*AllClient)
+	if !ok {
+		resp.Diagnostics.AddError(
+			"Unexpected Resource Configure Type",
+			fmt.Sprintf("Expected *AllClient, got: %T. Please report this issue to the provider developers.", req.ProviderData),
+		)
+		return
+	}
+	r.client = client
+}
+
+// Create attaches the policy to the user and sets the initial Terraform state.
+func (r *UserPolicyAttachmentRessource) Create(ctx context.Context, req resource.CreateRequest, resp *resource.CreateResponse) {
+	var plan UserPolicyAttachmentRessourceModel
+	resp.Diagnostics.Append(req.Plan.Get(ctx, &plan)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	err := r.client.RustClient.AttachUserPolicy(plan.User.ValueString(), plan.Policy.ValueString())
+	if err != nil {
+		resp.Diagnostics.AddError(
+			"Error attaching policy to user",
+			"Could not attach policy: "+err.Error(),
+		)
+		return
+	}
+
+	plan.ID = types.StringValue(plan.User.ValueString() + "/" + plan.Policy.ValueString())
+	tflog.Trace(ctx, "attached policy to user")
+	resp.Diagnostics.Append(resp.State.Set(ctx, &plan)...)
+}
+
+// Read preserves the last known state. The RustFS admin API exposes no
+// read-back enumerating a user's extra policy attachments; the attach
+// operation is idempotent and the user/policy pair is immutable, so the
+// last known state is kept (same pattern as rustfs_bucket).
+func (r *UserPolicyAttachmentRessource) Read(ctx context.Context, req resource.ReadRequest, resp *resource.ReadResponse) {
+	var state UserPolicyAttachmentRessourceModel
+	resp.Diagnostics.Append(req.State.Get(ctx, &state)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+	state.ID = types.StringValue(state.User.ValueString() + "/" + state.Policy.ValueString())
+	resp.Diagnostics.Append(resp.State.Set(ctx, &state)...)
+}
+
+// Update re-attaches the policy. All attributes are RequiresReplace, so
+// Terraform normally plans a replacement; re-attaching keeps this method
+// correct if it is invoked.
+func (r *UserPolicyAttachmentRessource) Update(ctx context.Context, req resource.UpdateRequest, resp *resource.UpdateResponse) {
+	var plan UserPolicyAttachmentRessourceModel
+	resp.Diagnostics.Append(req.Plan.Get(ctx, &plan)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	err := r.client.RustClient.AttachUserPolicy(plan.User.ValueString(), plan.Policy.ValueString())
+	if err != nil {
+		resp.Diagnostics.AddError(
+			"Error attaching policy to user",
+			"Could not attach policy: "+err.Error(),
+		)
+		return
+	}
+
+	plan.ID = types.StringValue(plan.User.ValueString() + "/" + plan.Policy.ValueString())
+	resp.Diagnostics.Append(resp.State.Set(ctx, &plan)...)
+}
+
+// Delete detaches the policy from the user and removes the Terraform state on success.
+func (r *UserPolicyAttachmentRessource) Delete(ctx context.Context, req resource.DeleteRequest, resp *resource.DeleteResponse) {
+	var data UserPolicyAttachmentRessourceModel
+	resp.Diagnostics.Append(req.State.Get(ctx, &data)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	err := r.client.RustClient.DetachUserPolicy(data.User.ValueString(), data.Policy.ValueString())
+	if err != nil {
+		resp.Diagnostics.AddError(
+			"Error detaching policy from user",
+			"Could not detach policy: "+err.Error(),
+		)
+		return
+	}
+	tflog.Trace(ctx, "detached policy from user")
+}
+
+// ImportState supports importing an attachment using the composite
+// <user>/<policy> identifier.
+func (r *UserPolicyAttachmentRessource) ImportState(ctx context.Context, req resource.ImportStateRequest, resp *resource.ImportStateResponse) {
+	parts := strings.Split(req.ID, "/")
+	if len(parts) != 2 || parts[0] == "" || parts[1] == "" {
+		resp.Diagnostics.AddError(
+			"Invalid import ID",
+			"Expected format: <user>/<policy>",
+		)
+		return
+	}
+	resp.Diagnostics.Append(resp.State.SetAttribute(ctx, path.Root("user"), parts[0])...)
+	resp.Diagnostics.Append(resp.State.SetAttribute(ctx, path.Root("policy"), parts[1])...)
+}

--- a/provider/rustfs_user_policy_attachment_ressource_test.go
+++ b/provider/rustfs_user_policy_attachment_ressource_test.go
@@ -40,24 +40,24 @@ func TestAccUserPolicyAttachmentResource(t *testing.T) {
 
 func testAccUserPolicyAttachmentConfig(userName, policyName string) string {
 	return testAccProviderConfig() + fmt.Sprintf(`
-resource "rustfs_user" "test" {
-  access_key = "%s"
-  secret_key = "superSecret123!"
-  policy     = "readonly"
-}
 resource "rustfs_policy" "test" {
   name = "%s"
-  statement {
+  statement = [{
     effect    = "Allow"
     action    = ["s3:GetObject"]
     ressource = ["arn:aws:s3:::accbucket/*"]
-  }
+  }]
+}
+resource "rustfs_user" "test" {
+  access_key = "%s"
+  secret_key = "superSecret123!"
+  policy     = rustfs_policy.test.name
 }
 resource "rustfs_user_policy_attachment" "test" {
   user   = rustfs_user.test.access_key
   policy = rustfs_policy.test.name
 }
-`, userName, policyName)
+`, policyName, userName)
 }
 
 func testAccCheckUserPolicyAttachmentDestroy(s *terraform.State) error {

--- a/provider/rustfs_user_policy_attachment_ressource_test.go
+++ b/provider/rustfs_user_policy_attachment_ressource_test.go
@@ -1,0 +1,78 @@
+package provider
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-testing/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/terraform"
+)
+
+func TestAccUserPolicyAttachmentResource(t *testing.T) {
+	userName := fmt.Sprintf("tf-test-upa-%d", acctest.RandInt())
+	policyName := fmt.Sprintf("accpolicy-%d", acctest.RandInt())
+	resourceName := "rustfs_user_policy_attachment.test"
+	attachmentID := userName + "/" + policyName
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		CheckDestroy:             testAccCheckUserPolicyAttachmentDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccUserPolicyAttachmentConfig(userName, policyName),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceName, "user", userName),
+					resource.TestCheckResourceAttr(resourceName, "policy", policyName),
+					resource.TestCheckResourceAttr(resourceName, "id", attachmentID),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateId:     attachmentID,
+			},
+		},
+	})
+}
+
+func testAccUserPolicyAttachmentConfig(userName, policyName string) string {
+	return testAccProviderConfig() + fmt.Sprintf(`
+resource "rustfs_user" "test" {
+  access_key = "%s"
+  secret_key = "superSecret123!"
+  policy     = "readonly"
+}
+resource "rustfs_policy" "test" {
+  name = "%s"
+  statement {
+    effect    = "Allow"
+    action    = ["s3:GetObject"]
+    ressource = ["arn:aws:s3:::accbucket/*"]
+  }
+}
+resource "rustfs_user_policy_attachment" "test" {
+  user   = rustfs_user.test.access_key
+  policy = rustfs_policy.test.name
+}
+`, userName, policyName)
+}
+
+func testAccCheckUserPolicyAttachmentDestroy(s *terraform.State) error {
+	client := testAccRustClient()
+	for _, rs := range s.RootModule().Resources {
+		if rs.Type != "rustfs_user_policy_attachment" {
+			continue
+		}
+		user := rs.Primary.Attributes["user"]
+		if user == "" {
+			continue
+		}
+		if _, err := client.ReadUserAccount(user); err == nil {
+			return fmt.Errorf("user %s still exists", user)
+		}
+	}
+	return nil
+}


### PR DESCRIPTION
**Issue:** https://github.com/weinmann-emt/terraform-provider-rustfs/issues/90

Add `rustfs_user_policy_attachment` resource to allow multiple policies per IAM user.

Closes #90

## Changes
- `pkg/rustfs/policy_attachment.go`: attach/detach for users via `POST idp/builtin/policy/attach` / `detach` (`{"user":..., "policies":[...]}`).
- `provider/rustfs_user_policy_attachment_ressource.go`: CRUD + import (`user/policy`).
- Registered in `provider.go Resources()`; unit + acceptance tests; docs + example.

## Testing
- `go build ./...`, `go vet ./...` pass; httptest unit tests pass; `TestAccUserPolicyAttachmentResource` passes against a live RustFS.
- golangci-lint: no new findings; gofmt clean.
