### PR TITLE
feat: surface expiration and scoped policy on rustfs_serviceaccount (#91)

### DIFF
--- a/docs/resources/serviceaccount.md
+++ b/docs/resources/serviceaccount.md
@@ -24,8 +24,8 @@ Manage ServiceUser/API Keys
 ### Optional
 
 - `description` (String) Short description of the scope we plan to use this token
-- `expiration` (String) Expiration timestamp in RFC3339 format (e.g. 2030-01-01T00:00:00.000Z). Defaults to 9999-01-01T00:00:00.000Z.
-- `policy` (String) Canned policy the service account is scoped to. Changing this forces a new resource to be created.
+- `expiration` (String) Expiration timestamp in RFC3339 format without fractional seconds (e.g. 2030-01-01T00:00:00Z). Defaults to 9999-01-01T00:00:00Z.
+- `policy` (String) IAM policy document (JSON) the service account is scoped to. Changing this forces a new resource to be created.
 - `user` (String) Optional user the token should be scoped to
 
 ### Read-Only

--- a/docs/resources/serviceaccount.md
+++ b/docs/resources/serviceaccount.md
@@ -24,7 +24,13 @@ Manage ServiceUser/API Keys
 ### Optional
 
 - `description` (String) Short description of the scope we plan to use this token
+- `expiration` (String) Expiration timestamp in RFC3339 format (e.g. 2030-01-01T00:00:00.000Z). Defaults to 9999-01-01T00:00:00.000Z.
+- `policy` (String) Canned policy the service account is scoped to. Changing this forces a new resource to be created.
 - `user` (String) Optional user the token should be scoped to
+
+### Read-Only
+
+- `implied_policy` (Boolean) Whether the implied policy is used (true when no explicit policy is set)
 
 ## Import
 

--- a/examples/resources/rustfs_serviceaccount/resource.tf
+++ b/examples/resources/rustfs_serviceaccount/resource.tf
@@ -3,7 +3,16 @@ resource "rustfs_serviceaccount" "ci_token" {
   secret_key  = "s3cret-token"
   name        = "CI Pipeline"
   description = "Token for CI/CD pipeline access"
-  expiration  = "2030-01-01T00:00:00.000Z"
-  policy      = "readonly"
-  user        = "myuser"
+  expiration  = "2030-01-01T00:00:00Z"
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Effect   = "Allow"
+        Action   = ["s3:GetObject"]
+        Resource = ["arn:aws:s3:::*"]
+      }
+    ]
+  })
+  user = "myuser"
 }

--- a/examples/resources/rustfs_serviceaccount/resource.tf
+++ b/examples/resources/rustfs_serviceaccount/resource.tf
@@ -3,5 +3,7 @@ resource "rustfs_serviceaccount" "ci_token" {
   secret_key  = "s3cret-token"
   name        = "CI Pipeline"
   description = "Token for CI/CD pipeline access"
+  expiration  = "2030-01-01T00:00:00.000Z"
+  policy      = "readonly"
   user        = "myuser"
 }

--- a/pkg/rustfs/service_account.go
+++ b/pkg/rustfs/service_account.go
@@ -123,7 +123,7 @@ func (c *RustfsAdmin) DeleteServiceAccount(account ServiceAccount) error {
 func normalizeServiceAccount(account *ServiceAccount) {
 	// Set some defaults
 	if account.Expiration == "" {
-		account.Expiration = "9999-01-01T00:00:00.000Z"
+		account.Expiration = "9999-01-01T00:00:00Z"
 	}
 	if account.Policy == "" {
 		account.ImpliedPolicy = true

--- a/pkg/rustfs/service_account_expiry_test.go
+++ b/pkg/rustfs/service_account_expiry_test.go
@@ -30,8 +30,8 @@ func TestCreateServiceAccountWithExpirySendsExpirationAndPolicy(t *testing.T) {
 		SecretKey:   "s3cret",
 		Name:        "tokens",
 		Description: "readonly",
-		Expiration:  "2030-01-01T00:00:00.000Z",
-		Policy:      "readwrite",
+		Expiration:  "2030-01-01T00:00:00Z",
+		Policy:      `{"Version":"2012-10-17","Statement":[{"Effect":"Allow","Action":["s3:GetObject"],"Resource":["arn:aws:s3:::*"]}]}`,
 		TargetUser:  "alice",
 	}
 	if err := client.CreateServiceAccount(account); err != nil {
@@ -40,7 +40,7 @@ func TestCreateServiceAccountWithExpirySendsExpirationAndPolicy(t *testing.T) {
 	if !strings.Contains(gotPath, "add-service-accounts") {
 		t.Errorf("wrong endpoint, path=%s", gotPath)
 	}
-	for _, want := range []string{`"expiration":"2030-01-01T00:00:00.000Z"`, `"policy":"readwrite"`, `"impliedPolicy":false`} {
+	for _, want := range []string{`"expiration":"2030-01-01T00:00:00Z"`, `"policy":"{\"Version\":\"2012-10-17\"`, `"impliedPolicy":false`} {
 		if !strings.Contains(gotBody, want) {
 			t.Errorf("missing %s in body: %s", want, gotBody)
 		}
@@ -71,7 +71,7 @@ func TestCreateServiceAccountWithExpiryDefaultsImpliedPolicy(t *testing.T) {
 	if err := client.CreateServiceAccount(account); err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
-	for _, want := range []string{`"impliedPolicy":true`, `"expiration":"9999-01-01T00:00:00.000Z"`} {
+	for _, want := range []string{`"impliedPolicy":true`, `"expiration":"9999-01-01T00:00:00Z"`} {
 		if !strings.Contains(gotBody, want) {
 			t.Errorf("missing %s in body: %s", want, gotBody)
 		}
@@ -96,12 +96,12 @@ func TestUpdateServiceAccountWithExpirySendsNewExpiration(t *testing.T) {
 
 	account := ServiceAccount{
 		AccessKey:  "sa-test",
-		Expiration: "2031-06-01T00:00:00.000Z",
+		Expiration: "2031-06-01T00:00:00Z",
 	}
 	if err := client.UpdateServiceAccount(account); err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
-	if !strings.Contains(gotBody, `"newExpiration":"2031-06-01T00:00:00.000Z"`) {
+	if !strings.Contains(gotBody, `"newExpiration":"2031-06-01T00:00:00Z"`) {
 		t.Errorf("expected newExpiration in body: %s", gotBody)
 	}
 }

--- a/pkg/rustfs/service_account_expiry_test.go
+++ b/pkg/rustfs/service_account_expiry_test.go
@@ -1,0 +1,107 @@
+package rustfs
+
+import (
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+func TestCreateServiceAccountWithExpirySendsExpirationAndPolicy(t *testing.T) {
+	var gotPath, gotBody string
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotPath = r.URL.Path
+		bodyBytes, _ := io.ReadAll(r.Body)
+		gotBody = string(bodyBytes)
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte("{}"))
+	}))
+	defer server.Close()
+
+	client := New(&RustfsAdminConfig{
+		Endpoint:     server.Listener.Addr().String(),
+		AccessKey:    "admin",
+		AccessSecret: "secret",
+	})
+
+	account := ServiceAccount{
+		AccessKey:   "sa-test",
+		SecretKey:   "s3cret",
+		Name:        "tokens",
+		Description: "readonly",
+		Expiration:  "2030-01-01T00:00:00.000Z",
+		Policy:      "readwrite",
+		TargetUser:  "alice",
+	}
+	if err := client.CreateServiceAccount(account); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !strings.Contains(gotPath, "add-service-accounts") {
+		t.Errorf("wrong endpoint, path=%s", gotPath)
+	}
+	for _, want := range []string{`"expiration":"2030-01-01T00:00:00.000Z"`, `"policy":"readwrite"`, `"impliedPolicy":false`} {
+		if !strings.Contains(gotBody, want) {
+			t.Errorf("missing %s in body: %s", want, gotBody)
+		}
+	}
+}
+
+func TestCreateServiceAccountWithExpiryDefaultsImpliedPolicy(t *testing.T) {
+	var gotBody string
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		bodyBytes, _ := io.ReadAll(r.Body)
+		gotBody = string(bodyBytes)
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte("{}"))
+	}))
+	defer server.Close()
+
+	client := New(&RustfsAdminConfig{
+		Endpoint:     server.Listener.Addr().String(),
+		AccessKey:    "admin",
+		AccessSecret: "secret",
+	})
+
+	account := ServiceAccount{
+		AccessKey: "sa-test",
+		SecretKey: "s3cret",
+		Name:      "tokens",
+	}
+	if err := client.CreateServiceAccount(account); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	for _, want := range []string{`"impliedPolicy":true`, `"expiration":"9999-01-01T00:00:00.000Z"`} {
+		if !strings.Contains(gotBody, want) {
+			t.Errorf("missing %s in body: %s", want, gotBody)
+		}
+	}
+}
+
+func TestUpdateServiceAccountWithExpirySendsNewExpiration(t *testing.T) {
+	var gotBody string
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		bodyBytes, _ := io.ReadAll(r.Body)
+		gotBody = string(bodyBytes)
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte("{}"))
+	}))
+	defer server.Close()
+
+	client := New(&RustfsAdminConfig{
+		Endpoint:     server.Listener.Addr().String(),
+		AccessKey:    "admin",
+		AccessSecret: "secret",
+	})
+
+	account := ServiceAccount{
+		AccessKey:  "sa-test",
+		Expiration: "2031-06-01T00:00:00.000Z",
+	}
+	if err := client.UpdateServiceAccount(account); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !strings.Contains(gotBody, `"newExpiration":"2031-06-01T00:00:00.000Z"`) {
+		t.Errorf("expected newExpiration in body: %s", gotBody)
+	}
+}

--- a/provider/rustfs_service_account_resource_test.go
+++ b/provider/rustfs_service_account_resource_test.go
@@ -115,3 +115,44 @@ func testAccSAClient() rustfs.RustfsAdmin {
 		AccessSecret: os.Getenv("RUSTFS_SECRET"),
 	})
 }
+
+func TestAccServiceAccountExpiryPolicyResource(t *testing.T) {
+	accessKey := fmt.Sprintf("tf-test-saexp-%d", acctest.RandInt())
+	resourceName := "rustfs_serviceaccount.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		CheckDestroy:             testAccCheckServiceAccountDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccServiceAccountExpiryPolicyConfig(accessKey, "2030-01-01T00:00:00.000Z", "readwrite"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckServiceAccountExists(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "access_key", accessKey),
+					resource.TestCheckResourceAttr(resourceName, "expiration", "2030-01-01T00:00:00.000Z"),
+					resource.TestCheckResourceAttr(resourceName, "policy", "readwrite"),
+					resource.TestCheckResourceAttr(resourceName, "implied_policy", "false"),
+				),
+			},
+			{
+				Config: testAccServiceAccountExpiryPolicyConfig(accessKey, "2031-01-01T00:00:00.000Z", "readwrite"),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceName, "expiration", "2031-01-01T00:00:00.000Z"),
+				),
+			},
+		},
+	})
+}
+
+func testAccServiceAccountExpiryPolicyConfig(accessKey, expiration, policy string) string {
+	return testAccProviderConfig() + fmt.Sprintf(`
+resource "rustfs_serviceaccount" "test" {
+  access_key  = "%s"
+  secret_key  = "superSecret123!"
+  name        = "expiryaccount"
+  expiration  = "%s"
+  policy      = "%s"
+}
+`, accessKey, expiration, policy)
+}

--- a/provider/rustfs_service_account_resource_test.go
+++ b/provider/rustfs_service_account_resource_test.go
@@ -119,6 +119,7 @@ func testAccSAClient() rustfs.RustfsAdmin {
 func TestAccServiceAccountExpiryPolicyResource(t *testing.T) {
 	accessKey := fmt.Sprintf("tf-test-saexp-%d", acctest.RandInt())
 	resourceName := "rustfs_serviceaccount.test"
+	policyDoc := `{"Version":"2012-10-17","Statement":[{"Effect":"Allow","Action":["s3:GetObject"],"Resource":["arn:aws:s3:::*"]}]}`
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:                 func() { testAccPreCheck(t) },
@@ -126,19 +127,19 @@ func TestAccServiceAccountExpiryPolicyResource(t *testing.T) {
 		CheckDestroy:             testAccCheckServiceAccountDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccServiceAccountExpiryPolicyConfig(accessKey, "2030-01-01T00:00:00.000Z", "readwrite"),
+				Config: testAccServiceAccountExpiryPolicyConfig(accessKey, "2030-01-01T00:00:00Z", policyDoc),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckServiceAccountExists(resourceName),
 					resource.TestCheckResourceAttr(resourceName, "access_key", accessKey),
-					resource.TestCheckResourceAttr(resourceName, "expiration", "2030-01-01T00:00:00.000Z"),
-					resource.TestCheckResourceAttr(resourceName, "policy", "readwrite"),
+					resource.TestCheckResourceAttr(resourceName, "expiration", "2030-01-01T00:00:00Z"),
+					resource.TestCheckResourceAttr(resourceName, "policy", policyDoc),
 					resource.TestCheckResourceAttr(resourceName, "implied_policy", "false"),
 				),
 			},
 			{
-				Config: testAccServiceAccountExpiryPolicyConfig(accessKey, "2031-01-01T00:00:00.000Z", "readwrite"),
+				Config: testAccServiceAccountExpiryPolicyConfig(accessKey, "2031-01-01T00:00:00Z", policyDoc),
 				Check: resource.ComposeTestCheckFunc(
-					resource.TestCheckResourceAttr(resourceName, "expiration", "2031-01-01T00:00:00.000Z"),
+					resource.TestCheckResourceAttr(resourceName, "expiration", "2031-01-01T00:00:00Z"),
 				),
 			},
 		},
@@ -152,7 +153,7 @@ resource "rustfs_serviceaccount" "test" {
   secret_key  = "superSecret123!"
   name        = "expiryaccount"
   expiration  = "%s"
-  policy      = "%s"
+  policy      = %q
 }
 `, accessKey, expiration, policy)
 }

--- a/provider/rustfs_service_account_ressource.go
+++ b/provider/rustfs_service_account_ressource.go
@@ -8,6 +8,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringdefault"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-plugin-log/tflog"
@@ -15,11 +16,14 @@ import (
 )
 
 type serviceAccountResourceModel struct {
-	AccessKey   types.String `tfsdk:"access_key"`
-	SecretKey   types.String `tfsdk:"secret_key"`
-	Name        types.String `tfsdk:"name"`
-	Description types.String `tfsdk:"description"`
-	TargetUser  types.String `tfsdk:"user"`
+	AccessKey     types.String `tfsdk:"access_key"`
+	SecretKey     types.String `tfsdk:"secret_key"`
+	Name          types.String `tfsdk:"name"`
+	Description   types.String `tfsdk:"description"`
+	TargetUser    types.String `tfsdk:"user"`
+	Expiration    types.String `tfsdk:"expiration"`
+	Policy        types.String `tfsdk:"policy"`
+	ImpliedPolicy types.Bool   `tfsdk:"implied_policy"`
 }
 
 // Ensure the implementation satisfies the expected interfaces.
@@ -72,6 +76,23 @@ func (r *ServiceAccountRessource) Schema(_ context.Context, _ resource.SchemaReq
 					stringplanmodifier.RequiresReplace(),
 				},
 			},
+			"expiration": schema.StringAttribute{
+				Optional:            true,
+				Computed:            true,
+				Default:             stringdefault.StaticString("9999-01-01T00:00:00.000Z"),
+				MarkdownDescription: "Expiration timestamp in RFC3339 format (e.g. 2030-01-01T00:00:00.000Z). Defaults to 9999-01-01T00:00:00.000Z.",
+			},
+			"policy": schema.StringAttribute{
+				Optional:            true,
+				MarkdownDescription: "Canned policy the service account is scoped to. Changing this forces a new resource to be created.",
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.RequiresReplace(),
+				},
+			},
+			"implied_policy": schema.BoolAttribute{
+				Computed:            true,
+				MarkdownDescription: "Whether the implied policy is used (true when no explicit policy is set).",
+			},
 		},
 	}
 }
@@ -109,6 +130,8 @@ func (r *ServiceAccountRessource) Create(ctx context.Context, req resource.Creat
 		SecretKey:   plan.SecretKey.ValueString(),
 		Description: plan.Description.ValueString(),
 		TargetUser:  plan.TargetUser.ValueString(),
+		Expiration:  plan.Expiration.ValueString(),
+		Policy:      plan.Policy.ValueString(),
 	}
 	err := r.client.RustClient.CreateServiceAccount(account)
 	if err != nil {
@@ -119,6 +142,7 @@ func (r *ServiceAccountRessource) Create(ctx context.Context, req resource.Creat
 		return
 	}
 	tflog.Trace(ctx, "created a resource")
+	plan.ImpliedPolicy = types.BoolValue(plan.Policy.ValueString() == "")
 	resp.Diagnostics.Append(resp.State.Set(ctx, &plan)...)
 
 }
@@ -150,6 +174,13 @@ func (r *ServiceAccountRessource) Read(ctx context.Context, req resource.ReadReq
 
 	state.Name = types.StringValue(actual.Name)
 	state.Description = types.StringValue(actual.Description)
+	if actual.Expiration != "" {
+		state.Expiration = types.StringValue(actual.Expiration)
+	}
+	if actual.Policy != "" {
+		state.Policy = types.StringValue(actual.Policy)
+	}
+	state.ImpliedPolicy = types.BoolValue(actual.ImpliedPolicy)
 	// Save update status
 	resp.Diagnostics.Append(resp.State.Set(ctx, &state)...)
 	if resp.Diagnostics.HasError() {
@@ -172,6 +203,8 @@ func (r *ServiceAccountRessource) Update(ctx context.Context, req resource.Updat
 		SecretKey:   plan.SecretKey.ValueString(),
 		Description: plan.Description.ValueString(),
 		TargetUser:  plan.TargetUser.ValueString(),
+		Expiration:  plan.Expiration.ValueString(),
+		Policy:      plan.Policy.ValueString(),
 	}
 	err := r.client.RustClient.UpdateServiceAccount(account)
 	if err != nil {
@@ -184,6 +217,8 @@ func (r *ServiceAccountRessource) Update(ctx context.Context, req resource.Updat
 
 	plan.Name = types.StringValue(account.Name)
 	plan.Description = types.StringValue(account.Description)
+	plan.Expiration = types.StringValue(account.Expiration)
+	plan.ImpliedPolicy = types.BoolValue(account.Policy == "")
 
 	diags = resp.State.Set(ctx, plan)
 	resp.Diagnostics.Append(diags...)

--- a/provider/rustfs_service_account_ressource.go
+++ b/provider/rustfs_service_account_ressource.go
@@ -79,12 +79,12 @@ func (r *ServiceAccountRessource) Schema(_ context.Context, _ resource.SchemaReq
 			"expiration": schema.StringAttribute{
 				Optional:            true,
 				Computed:            true,
-				Default:             stringdefault.StaticString("9999-01-01T00:00:00.000Z"),
-				MarkdownDescription: "Expiration timestamp in RFC3339 format (e.g. 2030-01-01T00:00:00.000Z). Defaults to 9999-01-01T00:00:00.000Z.",
+				Default:             stringdefault.StaticString("9999-01-01T00:00:00Z"),
+				MarkdownDescription: "Expiration timestamp in RFC3339 format without fractional seconds (e.g. 2030-01-01T00:00:00Z). Defaults to 9999-01-01T00:00:00Z.",
 			},
 			"policy": schema.StringAttribute{
 				Optional:            true,
-				MarkdownDescription: "Canned policy the service account is scoped to. Changing this forces a new resource to be created.",
+				MarkdownDescription: "IAM policy document (JSON) the service account is scoped to. Changing this forces a new resource to be created.",
 				PlanModifiers: []planmodifier.String{
 					stringplanmodifier.RequiresReplace(),
 				},
@@ -173,14 +173,16 @@ func (r *ServiceAccountRessource) Read(ctx context.Context, req resource.ReadReq
 	}
 
 	state.Name = types.StringValue(actual.Name)
-	state.Description = types.StringValue(actual.Description)
+	if actual.Description != "" {
+		state.Description = types.StringValue(actual.Description)
+	}
 	if actual.Expiration != "" {
 		state.Expiration = types.StringValue(actual.Expiration)
 	}
-	if actual.Policy != "" {
+	state.ImpliedPolicy = types.BoolValue(actual.ImpliedPolicy)
+	if !actual.ImpliedPolicy && state.Policy.IsNull() {
 		state.Policy = types.StringValue(actual.Policy)
 	}
-	state.ImpliedPolicy = types.BoolValue(actual.ImpliedPolicy)
 	// Save update status
 	resp.Diagnostics.Append(resp.State.Set(ctx, &state)...)
 	if resp.Diagnostics.HasError() {
@@ -216,7 +218,9 @@ func (r *ServiceAccountRessource) Update(ctx context.Context, req resource.Updat
 	}
 
 	plan.Name = types.StringValue(account.Name)
-	plan.Description = types.StringValue(account.Description)
+	if account.Description != "" {
+		plan.Description = types.StringValue(account.Description)
+	}
 	plan.Expiration = types.StringValue(account.Expiration)
 	plan.ImpliedPolicy = types.BoolValue(account.Policy == "")
 


### PR DESCRIPTION
**Issue:** https://github.com/weinmann-emt/terraform-provider-rustfs/issues/91

Surface `expiration` and scoped `policy` on the existing `rustfs_serviceaccount` resource.

Closes #91

## Changes
- `provider/rustfs_service_account_ressource.go`: new optional `expiration` and `policy` attributes wired through create/update/read; consistent `implied_policy` handling.
- Backward compatible defaults; docs + example updated.

## Testing
- `go build ./...`, `go vet ./...` pass; httptest unit tests pass; `TestAccServiceAccountResource_basic|update` and `TestAccServiceAccountExpiryPolicyResource` pass against a live RustFS.
- golangci-lint: no new findings; gofmt clean.

## Note
Server canonicalizes `expiration` to whole seconds; docs note the canonical format.
