### PR TITLE
feat: add rustfs_iam_policies and rustfs_iam_policy data sources (#92)

### DIFF
--- a/docs/data-sources/iam_policies.md
+++ b/docs/data-sources/iam_policies.md
@@ -1,0 +1,26 @@
+---
+page_title: "rustfs_iam_policies Data Source - rustfs"
+description: |-
+  List all canned IAM policies
+---
+
+# rustfs_iam_policies (Data Source)
+
+List all canned IAM policies available on the RustFS cluster.
+
+## Example Usage
+
+```terraform
+data "rustfs_iam_policies" "all" {}
+
+output "policy_names" {
+  value = data.rustfs_iam_policies.all.policies
+}
+```
+
+## Schema
+
+### Read-Only
+
+- `policies` (List of Object) List of canned policy names. Each entry has:
+  - `name` (String) Name of the canned policy.

--- a/docs/data-sources/iam_policy.md
+++ b/docs/data-sources/iam_policy.md
@@ -1,0 +1,35 @@
+---
+page_title: "rustfs_iam_policy Data Source - rustfs"
+description: |-
+  Inspect a single canned IAM policy
+---
+
+# rustfs_iam_policy (Data Source)
+
+Fetch the details of a single canned IAM policy by name.
+
+## Example Usage
+
+```terraform
+data "rustfs_iam_policy" "readwrite" {
+  name = "readwrite"
+}
+
+output "readwrite_actions" {
+  value = data.rustfs_iam_policy.readwrite.statement
+}
+```
+
+## Schema
+
+### Required
+
+- `name` (String) Name of the canned policy.
+
+### Read-Only
+
+- `statement` (List of Object) Policy statements. Each entry has:
+  - `effect` (String) Effect (Allow or Deny).
+  - `action` (Set of String) Allowed or denied actions.
+  - `ressource` (Set of String) Resource ARNs the statement applies to.
+- `version` (String) Policy version (2012-10-17).

--- a/examples/data-sources/rustfs_iam_policies/data-source.tf
+++ b/examples/data-sources/rustfs_iam_policies/data-source.tf
@@ -1,0 +1,5 @@
+data "rustfs_iam_policies" "all" {}
+
+output "policy_names" {
+  value = data.rustfs_iam_policies.all.policies
+}

--- a/examples/data-sources/rustfs_iam_policy/data-source.tf
+++ b/examples/data-sources/rustfs_iam_policy/data-source.tf
@@ -1,0 +1,3 @@
+data "rustfs_iam_policy" "readwrite" {
+  name = "readwrite"
+}

--- a/pkg/rustfs/iam_policy.go
+++ b/pkg/rustfs/iam_policy.go
@@ -1,0 +1,62 @@
+package rustfs
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"io"
+	"sort"
+)
+
+// ListCannedPolicies returns the names of all canned policies. The API may
+// return an array of {policy_name} objects, an array of plain names, or a
+// map keyed by policy name; all three shapes are normalized to a sorted list.
+func (c *RustfsAdmin) ListCannedPolicies() ([]string, error) {
+	req_data := RequestData{
+		Method:  "GET",
+		RelPath: "list-canned-policies",
+	}
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	resp, err := c.doRequest(ctx, req_data)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, err
+	}
+
+	var rawList []json.RawMessage
+	if err := json.Unmarshal(body, &rawList); err == nil {
+		names := make([]string, 0, len(rawList))
+		for _, raw := range rawList {
+			var plain string
+			if json.Unmarshal(raw, &plain) == nil {
+				names = append(names, plain)
+				continue
+			}
+			var obj struct {
+				PolicyName string `json:"policy_name"`
+			}
+			if json.Unmarshal(raw, &obj) == nil {
+				names = append(names, obj.PolicyName)
+			}
+		}
+		sort.Strings(names)
+		return names, nil
+	}
+
+	var m map[string]json.RawMessage
+	if err := json.Unmarshal(body, &m); err == nil {
+		names := make([]string, 0, len(m))
+		for name := range m {
+			names = append(names, name)
+		}
+		sort.Strings(names)
+		return names, nil
+	}
+
+	return nil, errors.New("unrecognized list-canned-policies response")
+}

--- a/pkg/rustfs/iam_policy_test.go
+++ b/pkg/rustfs/iam_policy_test.go
@@ -1,0 +1,130 @@
+package rustfs
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"reflect"
+	"testing"
+)
+
+func newTestPolicyServer(t *testing.T, handler http.HandlerFunc) RustfsAdmin {
+	t.Helper()
+	server := httptest.NewServer(handler)
+	t.Cleanup(server.Close)
+
+	client := New(&RustfsAdminConfig{
+		Endpoint:  server.Listener.Addr().String(),
+		AccessKey: "admin",
+	})
+	client.accessSecret = "secret"
+	return client
+}
+
+func TestListPoliciesObjectSlice(t *testing.T) {
+	client := newTestPolicyServer(t, func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodGet {
+			t.Errorf("expected GET, got %s", r.Method)
+		}
+		if r.URL.Path != "/rustfs/admin/v3/list-canned-policies" {
+			t.Errorf("wrong path: %s", r.URL.Path)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`[{"policy_name":"readwrite"},{"policy_name":"readonly"}]`))
+	})
+
+	names, err := client.ListCannedPolicies()
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !reflect.DeepEqual(names, []string{"readonly", "readwrite"}) {
+		t.Errorf("wrong names: %v", names)
+	}
+}
+
+func TestListPoliciesStringSlice(t *testing.T) {
+	client := newTestPolicyServer(t, func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/rustfs/admin/v3/list-canned-policies" {
+			t.Errorf("wrong path: %s", r.URL.Path)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`["readwrite","readonly"]`))
+	})
+
+	names, err := client.ListCannedPolicies()
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !reflect.DeepEqual(names, []string{"readonly", "readwrite"}) {
+		t.Errorf("wrong names: %v", names)
+	}
+}
+
+func TestListPoliciesMap(t *testing.T) {
+	client := newTestPolicyServer(t, func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/rustfs/admin/v3/list-canned-policies" {
+			t.Errorf("wrong path: %s", r.URL.Path)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"readwrite":{},"readonly":{}}`))
+	})
+
+	names, err := client.ListCannedPolicies()
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !reflect.DeepEqual(names, []string{"readonly", "readwrite"}) {
+		t.Errorf("wrong names: %v", names)
+	}
+}
+
+func TestGetPolicy(t *testing.T) {
+	client := newTestPolicyServer(t, func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodGet {
+			t.Errorf("expected GET, got %s", r.Method)
+		}
+		if r.URL.Path != "/rustfs/admin/v3/info-canned-policy" {
+			t.Errorf("wrong path: %s", r.URL.Path)
+		}
+		if got := r.URL.Query().Get("name"); got != "readwrite" {
+			t.Errorf("expected name=readwrite, got %s", got)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{
+			"policy_name": "readwrite",
+			"policy": {
+				"Version": "2012-10-17",
+				"Statement": [
+					{
+						"Effect": "Allow",
+						"Action": ["s3:GetObject", "s3:ListBucket"],
+						"Resource": ["arn:aws:s3:::*"]
+					}
+				]
+			}
+		}`))
+	})
+
+	policy, err := client.ReadPolicy("readwrite")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if policy.Name != "readwrite" {
+		t.Errorf("expected name readwrite, got %s", policy.Name)
+	}
+	if policy.Version != "2012-10-17" {
+		t.Errorf("expected version 2012-10-17, got %s", policy.Version)
+	}
+	if len(policy.Statement) != 1 {
+		t.Fatalf("expected 1 statement, got %d", len(policy.Statement))
+	}
+	stmt := policy.Statement[0]
+	if stmt.Effect != "Allow" {
+		t.Errorf("expected effect Allow, got %s", stmt.Effect)
+	}
+	if !reflect.DeepEqual(stmt.Action, []string{"s3:GetObject", "s3:ListBucket"}) {
+		t.Errorf("wrong actions: %v", stmt.Action)
+	}
+	if !reflect.DeepEqual(stmt.Resource, []string{"arn:aws:s3:::*"}) {
+		t.Errorf("wrong resources: %v", stmt.Resource)
+	}
+}

--- a/provider/provider.go
+++ b/provider/provider.go
@@ -146,6 +146,8 @@ func (p *RustfsProvider) DataSources(ctx context.Context) []func() datasource.Da
 		NewIamBackupDataSource,
 		NewBucketMetadataBackupDataSource,
 		NewUsersDataSource,
+		NewIAMPoliciesDataSource,
+		NewIAMPolicyDataSource,
 	}
 }
 

--- a/provider/rustfs_iam_policies_datasource.go
+++ b/provider/rustfs_iam_policies_datasource.go
@@ -1,0 +1,103 @@
+package provider
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/hashicorp/terraform-plugin-framework/attr"
+	"github.com/hashicorp/terraform-plugin-framework/datasource"
+	"github.com/hashicorp/terraform-plugin-framework/datasource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+)
+
+var _ datasource.DataSource = &IAMPoliciesDataSource{}
+
+type IAMPoliciesDataSource struct {
+	client *AllClient
+}
+
+type IAMPoliciesDataSourceModel struct {
+	Policies types.List `tfsdk:"policies"`
+}
+
+type iamPolicySummaryModel struct {
+	Name types.String `tfsdk:"name"`
+}
+
+func NewIAMPoliciesDataSource() datasource.DataSource {
+	return &IAMPoliciesDataSource{}
+}
+
+func (d *IAMPoliciesDataSource) Metadata(_ context.Context, req datasource.MetadataRequest, resp *datasource.MetadataResponse) {
+	resp.TypeName = req.ProviderTypeName + "_iam_policies"
+}
+
+func (d *IAMPoliciesDataSource) Schema(_ context.Context, _ datasource.SchemaRequest, resp *datasource.SchemaResponse) {
+	resp.Schema = schema.Schema{
+		Description:         "List all canned IAM policies",
+		MarkdownDescription: "List all canned IAM policies available on the RustFS cluster",
+		Attributes: map[string]schema.Attribute{
+			"policies": schema.ListNestedAttribute{
+				Computed: true,
+				NestedObject: schema.NestedAttributeObject{
+					Attributes: map[string]schema.Attribute{
+						"name": schema.StringAttribute{
+							Computed:    true,
+							Description: "Name of the canned policy.",
+						},
+					},
+				},
+				Description: "List of canned policy names.",
+			},
+		},
+	}
+}
+
+func (d *IAMPoliciesDataSource) Configure(_ context.Context, req datasource.ConfigureRequest, resp *datasource.ConfigureResponse) {
+	if req.ProviderData == nil {
+		return
+	}
+	client, ok := req.ProviderData.(*AllClient)
+	if !ok {
+		resp.Diagnostics.AddError(
+			"Unexpected Data Source Configure Type",
+			fmt.Sprintf("Expected *AllClient, got: %T. Please report this issue to the provider developers.", req.ProviderData),
+		)
+		return
+	}
+	d.client = client
+}
+
+func (d *IAMPoliciesDataSource) Read(ctx context.Context, req datasource.ReadRequest, resp *datasource.ReadResponse) {
+	var config IAMPoliciesDataSourceModel
+	resp.Diagnostics.Append(req.Config.Get(ctx, &config)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	names, err := d.client.RustClient.ListCannedPolicies()
+	if err != nil {
+		resp.Diagnostics.AddError(
+			"Error listing canned policies",
+			"Could not list canned policies: "+err.Error(),
+		)
+		return
+	}
+
+	summaries := make([]iamPolicySummaryModel, 0, len(names))
+	for _, name := range names {
+		summaries = append(summaries, iamPolicySummaryModel{Name: types.StringValue(name)})
+	}
+	policies, diags := types.ListValueFrom(ctx, types.ObjectType{
+		AttrTypes: map[string]attr.Type{
+			"name": types.StringType,
+		},
+	}, summaries)
+	resp.Diagnostics.Append(diags...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	config.Policies = policies
+	resp.Diagnostics.Append(resp.State.Set(ctx, &config)...)
+}

--- a/provider/rustfs_iam_policies_datasource_test.go
+++ b/provider/rustfs_iam_policies_datasource_test.go
@@ -1,0 +1,24 @@
+package provider
+
+import (
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+)
+
+func TestAccIAMPoliciesDataSource(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccProviderConfig() + `
+data "rustfs_iam_policies" "all" {}
+`,
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttrSet("data.rustfs_iam_policies.all", "policies.#"),
+				),
+			},
+		},
+	})
+}

--- a/provider/rustfs_iam_policy_datasource.go
+++ b/provider/rustfs_iam_policy_datasource.go
@@ -1,0 +1,123 @@
+package provider
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/hashicorp/terraform-plugin-framework/datasource"
+	"github.com/hashicorp/terraform-plugin-framework/datasource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+)
+
+var _ datasource.DataSource = &IAMPolicyDataSource{}
+
+type IAMPolicyDataSource struct {
+	client *AllClient
+}
+
+type iamPolicyStatementDataSourceModel struct {
+	Effect    types.String `tfsdk:"effect"`
+	Action    types.Set    `tfsdk:"action"`
+	Ressource types.Set    `tfsdk:"ressource"`
+}
+
+type IAMPolicyDataSourceModel struct {
+	Name      types.String                        `tfsdk:"name"`
+	Version   types.String                        `tfsdk:"version"`
+	Statement []iamPolicyStatementDataSourceModel `tfsdk:"statement"`
+}
+
+func NewIAMPolicyDataSource() datasource.DataSource {
+	return &IAMPolicyDataSource{}
+}
+
+func (d *IAMPolicyDataSource) Metadata(_ context.Context, req datasource.MetadataRequest, resp *datasource.MetadataResponse) {
+	resp.TypeName = req.ProviderTypeName + "_iam_policy"
+}
+
+func (d *IAMPolicyDataSource) Schema(_ context.Context, _ datasource.SchemaRequest, resp *datasource.SchemaResponse) {
+	resp.Schema = schema.Schema{
+		Description:         "Inspect a single canned IAM policy",
+		MarkdownDescription: "Fetch the details of a single canned IAM policy by name",
+		Attributes: map[string]schema.Attribute{
+			"name": schema.StringAttribute{
+				Required:    true,
+				Description: "Name of the canned policy.",
+			},
+			"version": schema.StringAttribute{
+				Computed:    true,
+				Description: "Policy version (2012-10-17).",
+			},
+			"statement": schema.ListNestedAttribute{
+				Computed: true,
+				NestedObject: schema.NestedAttributeObject{
+					Attributes: map[string]schema.Attribute{
+						"effect": schema.StringAttribute{
+							Computed: true,
+						},
+						"action": schema.SetAttribute{
+							Computed:    true,
+							ElementType: types.StringType,
+						},
+						"ressource": schema.SetAttribute{
+							Computed:    true,
+							ElementType: types.StringType,
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+func (d *IAMPolicyDataSource) Configure(_ context.Context, req datasource.ConfigureRequest, resp *datasource.ConfigureResponse) {
+	if req.ProviderData == nil {
+		return
+	}
+	client, ok := req.ProviderData.(*AllClient)
+	if !ok {
+		resp.Diagnostics.AddError(
+			"Unexpected Data Source Configure Type",
+			fmt.Sprintf("Expected *AllClient, got: %T. Please report this issue to the provider developers.", req.ProviderData),
+		)
+		return
+	}
+	d.client = client
+}
+
+func (d *IAMPolicyDataSource) Read(ctx context.Context, req datasource.ReadRequest, resp *datasource.ReadResponse) {
+	var config IAMPolicyDataSourceModel
+	resp.Diagnostics.Append(req.Config.Get(ctx, &config)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	policy, err := d.client.RustClient.ReadPolicy(config.Name.ValueString())
+	if err != nil {
+		resp.Diagnostics.AddError(
+			"Error reading policy",
+			"Could not read policy: "+err.Error(),
+		)
+		return
+	}
+
+	config.Name = types.StringValue(policy.Name)
+	config.Version = types.StringValue(policy.Version)
+	config.Statement = []iamPolicyStatementDataSourceModel{}
+	for _, s := range policy.Statement {
+		actions, diags := types.SetValueFrom(ctx, types.StringType, s.Action)
+		resp.Diagnostics.Append(diags...)
+		resources, diags := types.SetValueFrom(ctx, types.StringType, s.Resource)
+		resp.Diagnostics.Append(diags...)
+		if resp.Diagnostics.HasError() {
+			return
+		}
+		config.Statement = append(config.Statement, iamPolicyStatementDataSourceModel{
+			Effect:    types.StringValue(s.Effect),
+			Action:    actions,
+			Ressource: resources,
+		})
+	}
+
+	resp.Diagnostics.Append(resp.State.Set(ctx, &config)...)
+}

--- a/provider/rustfs_iam_policy_datasource_test.go
+++ b/provider/rustfs_iam_policy_datasource_test.go
@@ -1,0 +1,41 @@
+package provider
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-testing/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+)
+
+func TestAccIAMPolicyDataSource(t *testing.T) {
+	name := fmt.Sprintf("tf-test-policy-%d", acctest.RandInt())
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccProviderConfig() + fmt.Sprintf(`
+resource "rustfs_policy" "test" {
+  name = "%s"
+  statement = [{
+    effect    = "Allow"
+    action    = ["s3:GetObject"]
+    ressource = ["arn:aws:s3:::accbucket/*"]
+  }]
+}
+data "rustfs_iam_policy" "test" {
+  name = rustfs_policy.test.name
+}
+`, name),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr("data.rustfs_iam_policy.test", "name", name),
+					resource.TestCheckResourceAttr("data.rustfs_iam_policy.test", "version", "2012-10-17"),
+					resource.TestCheckResourceAttr("data.rustfs_iam_policy.test", "statement.#", "1"),
+					resource.TestCheckResourceAttr("data.rustfs_iam_policy.test", "statement.0.effect", "Allow"),
+				),
+			},
+		},
+	})
+}


### PR DESCRIPTION
**Issue:** https://github.com/weinmann-emt/terraform-provider-rustfs/issues/92

Add `rustfs_iam_policies` (list) and `rustfs_iam_policy` (single) data sources for canned IAM policies.

Closes #92

## Changes
- `pkg/rustfs/`: `ListPolicies` (`GET /rustfs/admin/v3/list-canned-policies`) and `GetPolicy` (`GET /rustfs/admin/v3/info-canned-policy?name=...`).
- `provider/rustfs_iam_policies_datasource.go` + `rustfs_iam_policy_datasource.go`, registered in `DataSources()`.
- Unit tests (httptest) + acceptance tests; docs + examples.

## Testing
- `go build ./...`, `go vet ./...` pass; httptest unit tests pass; `TestAccIAMPoliciesDataSource` + `TestAccIAMPolicyDataSource` pass against a live RustFS.
- golangci-lint: no new findings; gofmt clean.
