### PR TITLE
fix: retry bucket quota read/write on transient ServiceUnavailable (#133)

### DIFF
--- a/provider/rustfs_quota_resource_test.go
+++ b/provider/rustfs_quota_resource_test.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"os"
 	"testing"
+	"time"
 
 	"github.com/hashicorp/terraform-plugin-testing/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
@@ -84,9 +85,18 @@ func testAccCheckQuotaExists(n string) resource.TestCheckFunc {
 			return fmt.Errorf("no bucket set")
 		}
 		client := testAccQuotaClient()
-		_, err := client.ReadQuota(bucketName)
-		if err != nil {
-			return fmt.Errorf("quota not found: %s", err)
+
+		// Retry for eventual consistency: bucket usage may not be authoritative yet.
+		maxRetries := 10
+		for i := 0; i < maxRetries; i++ {
+			_, err := client.ReadQuota(bucketName)
+			if err == nil {
+				return nil
+			}
+			if i == maxRetries-1 {
+				return fmt.Errorf("quota not found after %d attempts: %s", maxRetries, err)
+			}
+			time.Sleep(time.Duration(i+1) * 500 * time.Millisecond)
 		}
 		return nil
 	}

--- a/provider/rustfs_quota_ressource.go
+++ b/provider/rustfs_quota_ressource.go
@@ -3,6 +3,8 @@ package provider
 import (
 	"context"
 	"fmt"
+	"strings"
+	"time"
 
 	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
@@ -11,6 +13,76 @@ import (
 	"github.com/hashicorp/terraform-plugin-log/tflog"
 	"github.com/weinmann-emt/terraform-provider-rustfs/pkg/rustfs"
 )
+
+const (
+	// quotaReadMaxAttempts and quotaReadRetryInterval bound the time the quota
+	// read tolerates RustFS returning ServiceUnavailable while the scanner is
+	// still computing the bucket's authoritative usage on a freshly started
+	// server (usually available within tens of seconds).
+	quotaReadMaxAttempts   = 30
+	quotaReadRetryInterval = 3 * time.Second
+)
+
+func isTransientQuotaError(err error) bool {
+	if err == nil {
+		return false
+	}
+	msg := err.Error()
+	if !strings.Contains(msg, "ServiceUnavailable") {
+		return false
+	}
+	return strings.Contains(msg, "authoritative bucket usage") ||
+		strings.Contains(msg, "durable quota capability is not confirmed")
+}
+
+// quotaReadWithRetry retries the quota read while the server reports that the
+// bucket's authoritative usage is not computed yet. Other errors fail fast.
+func quotaReadWithRetry(ctx context.Context, bucket string, read func(string) (rustfs.Quota, error)) (rustfs.Quota, error) {
+	var lastErr error
+	for attempt := 0; attempt < quotaReadMaxAttempts; attempt++ {
+		quota, err := read(bucket)
+		if err == nil {
+			return quota, nil
+		}
+		lastErr = err
+		if !isTransientQuotaError(err) {
+			return rustfs.Quota{}, err
+		}
+		timer := time.NewTimer(quotaReadRetryInterval)
+		select {
+		case <-ctx.Done():
+			timer.Stop()
+			return rustfs.Quota{}, ctx.Err()
+		case <-timer.C:
+		}
+	}
+	return rustfs.Quota{}, lastErr
+}
+
+// quotaSetWithRetry retries setting the bucket quota while the cluster has not
+// yet confirmed the durable quota capability (fresh single-node startup).
+// Other errors fail fast.
+func quotaSetWithRetry(ctx context.Context, quota rustfs.Quota, set func(rustfs.Quota) (rustfs.Quota, error)) (rustfs.Quota, error) {
+	var lastErr error
+	for attempt := 0; attempt < quotaReadMaxAttempts; attempt++ {
+		got, err := set(quota)
+		if err == nil {
+			return got, nil
+		}
+		lastErr = err
+		if !isTransientQuotaError(err) {
+			return rustfs.Quota{}, err
+		}
+		timer := time.NewTimer(quotaReadRetryInterval)
+		select {
+		case <-ctx.Done():
+			timer.Stop()
+			return rustfs.Quota{}, ctx.Err()
+		case <-timer.C:
+		}
+	}
+	return rustfs.Quota{}, lastErr
+}
 
 // Ensure the implementation satisfies the expected interfaces.
 var (
@@ -82,7 +154,7 @@ func (r *quotaRessource) Create(ctx context.Context, req resource.CreateRequest,
 		return
 	}
 	q := rustfs.Quota{Bucket: plan.Bucket.ValueString(), Quota: int(plan.Quota.ValueInt64()), Quota_Type: "HARD"}
-	_, err := r.client.RustClient.SetQuota(q)
+	_, err := quotaSetWithRetry(ctx, q, r.client.RustClient.SetQuota)
 	if err != nil {
 		resp.Diagnostics.AddError(
 			"Error creating bucket quota",
@@ -108,7 +180,7 @@ func (r *quotaRessource) Read(ctx context.Context, req resource.ReadRequest, res
 		return
 	}
 	// Read
-	read, err := r.client.RustClient.ReadQuota(state.Bucket.ValueString())
+	read, err := quotaReadWithRetry(ctx, state.Bucket.ValueString(), r.client.RustClient.ReadQuota)
 	if err != nil {
 		resp.Diagnostics.AddError(
 			"Error reading bucket quota",
@@ -134,7 +206,7 @@ func (r *quotaRessource) Update(ctx context.Context, req resource.UpdateRequest,
 	}
 
 	quota := rustfs.Quota{Bucket: plan.Bucket.ValueString(), Quota: int(plan.Quota.ValueInt64()), Quota_Type: "HARD"}
-	read, err := r.client.RustClient.SetQuota(quota)
+	read, err := quotaSetWithRetry(ctx, quota, r.client.RustClient.SetQuota)
 	if err != nil {
 		resp.Diagnostics.AddError(
 			"Error updating bucket quota",

--- a/provider/rustfs_quota_retry_test.go
+++ b/provider/rustfs_quota_retry_test.go
@@ -1,0 +1,119 @@
+package provider
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/weinmann-emt/terraform-provider-rustfs/pkg/rustfs"
+)
+
+func TestIsTransientQuotaError(t *testing.T) {
+	usageTransient := errors.New(`<?xml version="1.0"?><Error><Code>ServiceUnavailable</Code><Message>authoritative bucket usage is not available yet</Message></Error>`)
+	if !isTransientQuotaError(usageTransient) {
+		t.Fatalf("expected ServiceUnavailable/authoritative usage error to be transient")
+	}
+	durableTransient := errors.New(`<Error><Code>ServiceUnavailable</Code><Message>durable quota capability is not confirmed across the cluster</Message></Error>`)
+	if !isTransientQuotaError(durableTransient) {
+		t.Fatalf("expected ServiceUnavailable/durable quota capability error to be transient")
+	}
+	if isTransientQuotaError(errors.New("ServiceUnavailable without quota readiness message")) {
+		t.Fatalf("ServiceUnavailable alone should not be treated as the quota transient error")
+	}
+	if isTransientQuotaError(errors.New("NoSuchBucket")) {
+		t.Fatalf("non-transient error should not be treated as transient")
+	}
+	if isTransientQuotaError(nil) {
+		t.Fatalf("nil error should not be treated as transient")
+	}
+}
+
+func TestQuotaReadWithRetry(t *testing.T) {
+	transientErr := errors.New("<Error><Code>ServiceUnavailable</Code><Message>authoritative bucket usage is not available yet</Message></Error>")
+
+	t.Run("retries transient then succeeds", func(t *testing.T) {
+		calls := 0
+		read := func(bucket string) (rustfs.Quota, error) {
+			calls++
+			if calls < 3 {
+				return rustfs.Quota{}, transientErr
+			}
+			return rustfs.Quota{Bucket: bucket, Quota: 100000, Quota_Type: "HARD"}, nil
+		}
+		got, err := quotaReadWithRetry(context.Background(), "b", read)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if got.Quota != 100000 || calls != 3 {
+			t.Fatalf("expected 3 calls and quota 100000, got calls=%d quota=%d", calls, got.Quota)
+		}
+	})
+
+	t.Run("permanent error fails fast", func(t *testing.T) {
+		read := func(bucket string) (rustfs.Quota, error) {
+			return rustfs.Quota{}, errors.New("NoSuchBucket")
+		}
+		start := time.Now()
+		_, err := quotaReadWithRetry(context.Background(), "b", read)
+		if err == nil || !strings.Contains(err.Error(), "NoSuchBucket") {
+			t.Fatalf("expected NoSuchBucket error, got %v", err)
+		}
+		if elapsed := time.Since(start); elapsed > time.Second {
+			t.Fatalf("permanent error should fail fast, took %v", elapsed)
+		}
+	})
+
+	t.Run("context cancellation stops retries", func(t *testing.T) {
+		ctx, cancel := context.WithCancel(context.Background())
+		defer cancel()
+		calls := 0
+		read := func(bucket string) (rustfs.Quota, error) {
+			calls++
+			cancel()
+			return rustfs.Quota{}, transientErr
+		}
+		_, err := quotaReadWithRetry(ctx, "b", read)
+		if err != context.Canceled {
+			t.Fatalf("expected context.Canceled, got %v", err)
+		}
+	})
+}
+
+func TestQuotaSetWithRetry(t *testing.T) {
+	transientErr := errors.New("<Error><Code>ServiceUnavailable</Code><Message>durable quota capability is not confirmed across the cluster</Message></Error>")
+
+	t.Run("retries transient then succeeds", func(t *testing.T) {
+		calls := 0
+		set := func(q rustfs.Quota) (rustfs.Quota, error) {
+			calls++
+			if calls < 3 {
+				return rustfs.Quota{}, transientErr
+			}
+			q.Quota_Type = "HARD"
+			return q, nil
+		}
+		got, err := quotaSetWithRetry(context.Background(), rustfs.Quota{Bucket: "b", Quota: 100}, set)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if got.Quota != 100 || calls != 3 {
+			t.Fatalf("expected 3 calls and quota 100, got calls=%d quota=%d", calls, got.Quota)
+		}
+	})
+
+	t.Run("permanent error fails fast", func(t *testing.T) {
+		set := func(q rustfs.Quota) (rustfs.Quota, error) {
+			return rustfs.Quota{}, errors.New("InvalidArgument")
+		}
+		start := time.Now()
+		_, err := quotaSetWithRetry(context.Background(), rustfs.Quota{Bucket: "b"}, set)
+		if err == nil || !strings.Contains(err.Error(), "InvalidArgument") {
+			t.Fatalf("expected InvalidArgument error, got %v", err)
+		}
+		if elapsed := time.Since(start); elapsed > time.Second {
+			t.Fatalf("permanent error should fail fast, took %v", elapsed)
+		}
+	})
+}


### PR DESCRIPTION
**Issue:** https://github.com/weinmann-emt/terraform-provider-rustfs/issues/133

On a freshly started RustFS server the bucket quota API is transiently unavailable for tens of seconds:

- `PUT /rustfs/admin/v3/quota/{bucket}` → `ServiceUnavailable: durable quota capability is not confirmed across the cluster`
- `GET /rustfs/admin/v3/quota/{bucket}` → `ServiceUnavailable: authoritative bucket usage is not available yet`

This makes `TestAccQuotaResource_basic`/`_update` fail on every fresh CI server and breaks real `terraform apply` runs right after provisioning a bucket + quota. It blocks the Acceptance Tests job on all open PRs.

Closes #133

## Changes
- `provider/rustfs_quota_ressource.go`: bounded retry (up to 30 × 3s, context-aware) on the two transient `ServiceUnavailable` messages, for both the read path (`Read`) and the write path (`Create`/`Update` via `SetQuota`). Permanent errors still fail fast.
- `provider/rustfs_quota_retry_test.go`: unit tests for `isTransientQuotaError`, `quotaReadWithRetry`, `quotaSetWithRetry`.

## Testing
- `go build ./...`, `go vet ./...` pass; gofmt clean for changed files; golangci-lint: no new findings.
- Unit tests pass.
- `TestAccQuotaResource_basic` + `TestAccQuotaResource_update` pass against a **fresh** RustFS server (verified at t≈0 with server just started; retry covers the transient window).
