### PR TITLE
feat: add rustfs_user_mfa data source (#94)

### DIFF
--- a/docs/data-sources/user_mfa.md
+++ b/docs/data-sources/user_mfa.md
@@ -1,0 +1,35 @@
+---
+page_title: "rustfs_user_mfa Data Source - rustfs"
+description: |-
+  Read the MFA status of a RustFS user
+---
+
+# rustfs_user_mfa (Data Source)
+
+Read the second-factor (MFA) status of a RustFS user by access key.
+
+The admin API only allows inspecting a user's MFA state; enrollment is performed by the user through the console.
+
+## Example Usage
+
+```terraform
+data "rustfs_user_mfa" "alice" {
+  access_key = rustfs_user.alice.access_key
+}
+
+output "alice_mfa_enabled" {
+  value = data.rustfs_user_mfa.alice.enabled
+}
+```
+
+## Schema
+
+### Required
+
+- `access_key` (String) Access key of the user.
+
+### Read-Only
+
+- `activated_at` (String) RFC3339 timestamp of when the second factor was activated, if enabled.
+- `enabled` (Boolean) Whether two-factor authentication is enabled for the user.
+- `recovery_codes_remaining` (Number) Number of unused recovery codes remaining for the user.

--- a/examples/data-sources/rustfs_user_mfa/data-source.tf
+++ b/examples/data-sources/rustfs_user_mfa/data-source.tf
@@ -1,0 +1,7 @@
+data "rustfs_user_mfa" "alice" {
+  access_key = rustfs_user.alice.access_key
+}
+
+output "alice_mfa_enabled" {
+  value = data.rustfs_user_mfa.alice.enabled
+}

--- a/pkg/rustfs/mfa.go
+++ b/pkg/rustfs/mfa.go
@@ -1,0 +1,49 @@
+package rustfs
+
+import (
+	"context"
+	"encoding/json"
+	"net/url"
+)
+
+type UserMFAStatus struct {
+	AccessKey              string `json:"access_key"`
+	Enabled                bool   `json:"enabled"`
+	ActivatedAt            string `json:"activated_at,omitempty"`
+	RecoveryCodesRemaining int    `json:"recovery_codes_remaining"`
+}
+
+// ReadUserMFA returns the MFA status of a user.
+func (c *RustfsAdmin) ReadUserMFA(accessKey string) (UserMFAStatus, error) {
+	var status UserMFAStatus
+	urlValues := make(url.Values)
+	urlValues.Set("accessKey", accessKey)
+	req_data := RequestData{
+		Method:      "GET",
+		RelPath:     "user/mfa",
+		QueryValues: urlValues,
+	}
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	resp, err := c.doRequest(ctx, req_data)
+	if err != nil {
+		return status, err
+	}
+	err = json.NewDecoder(resp.Body).Decode(&status)
+	return status, err
+}
+
+// ClearUserMFA clears the second factor of a user.
+func (c *RustfsAdmin) ClearUserMFA(accessKey string) error {
+	urlValues := make(url.Values)
+	urlValues.Set("accessKey", accessKey)
+	req_data := RequestData{
+		Method:      "DELETE",
+		RelPath:     "user/mfa",
+		QueryValues: urlValues,
+	}
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	_, err := c.doRequest(ctx, req_data)
+	return err
+}

--- a/pkg/rustfs/mfa_test.go
+++ b/pkg/rustfs/mfa_test.go
@@ -1,0 +1,87 @@
+package rustfs
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+func newTestMfaServer(t *testing.T, handler http.HandlerFunc) RustfsAdmin {
+	t.Helper()
+	server := httptest.NewServer(handler)
+	t.Cleanup(server.Close)
+
+	client := New(&RustfsAdminConfig{
+		Endpoint:     server.Listener.Addr().String(),
+		AccessKey:    "admin",
+		AccessSecret: "secret",
+	})
+	return client
+}
+
+func TestReadUserMFA(t *testing.T) {
+	var gotPath string
+	client := newTestMfaServer(t, func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodGet {
+			t.Errorf("expected GET, got %s", r.Method)
+		}
+		gotPath = r.URL.Path + "?" + r.URL.RawQuery
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"access_key":"alice","enabled":true,"activated_at":"2024-01-01T00:00:00Z","recovery_codes_remaining":5}`))
+	})
+
+	status, err := client.ReadUserMFA("alice")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !strings.Contains(gotPath, "/user/mfa") || !strings.Contains(gotPath, "accessKey=alice") {
+		t.Errorf("wrong request: %s", gotPath)
+	}
+	if !status.Enabled {
+		t.Error("expected enabled=true")
+	}
+	if status.AccessKey != "alice" {
+		t.Errorf("expected access_key alice, got %s", status.AccessKey)
+	}
+	if status.RecoveryCodesRemaining != 5 {
+		t.Errorf("expected 5 recovery codes remaining, got %d", status.RecoveryCodesRemaining)
+	}
+}
+
+func TestReadUserMFAWhenDisabled(t *testing.T) {
+	client := newTestMfaServer(t, func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"access_key":"alice","enabled":false,"recovery_codes_remaining":0}`))
+	})
+
+	status, err := client.ReadUserMFA("alice")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if status.Enabled {
+		t.Error("expected enabled=false")
+	}
+	if status.ActivatedAt != "" {
+		t.Errorf("expected empty activated_at, got %s", status.ActivatedAt)
+	}
+}
+
+func TestClearUserMFA(t *testing.T) {
+	var gotMethod, gotPath string
+	client := newTestMfaServer(t, func(w http.ResponseWriter, r *http.Request) {
+		gotMethod = r.Method
+		gotPath = r.URL.Path + "?" + r.URL.RawQuery
+		w.WriteHeader(http.StatusOK)
+	})
+
+	if err := client.ClearUserMFA("alice"); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if gotMethod != http.MethodDelete {
+		t.Errorf("expected DELETE, got %s", gotMethod)
+	}
+	if !strings.Contains(gotPath, "/user/mfa") || !strings.Contains(gotPath, "accessKey=alice") {
+		t.Errorf("wrong request: %s", gotPath)
+	}
+}

--- a/provider/provider.go
+++ b/provider/provider.go
@@ -146,6 +146,7 @@ func (p *RustfsProvider) DataSources(ctx context.Context) []func() datasource.Da
 		NewIamBackupDataSource,
 		NewBucketMetadataBackupDataSource,
 		NewUsersDataSource,
+		NewUserMfaDataSource,
 		NewIAMPoliciesDataSource,
 		NewIAMPolicyDataSource,
 	}

--- a/provider/rustfs_user_mfa_datasource.go
+++ b/provider/rustfs_user_mfa_datasource.go
@@ -1,0 +1,94 @@
+package provider
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/hashicorp/terraform-plugin-framework/datasource"
+	"github.com/hashicorp/terraform-plugin-framework/datasource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+)
+
+var _ datasource.DataSource = &UserMfaDataSource{}
+
+type UserMfaDataSource struct {
+	client *AllClient
+}
+
+type UserMfaDataSourceModel struct {
+	AccessKey              types.String `tfsdk:"access_key"`
+	Enabled                types.Bool   `tfsdk:"enabled"`
+	ActivatedAt            types.String `tfsdk:"activated_at"`
+	RecoveryCodesRemaining types.Int64  `tfsdk:"recovery_codes_remaining"`
+}
+
+func NewUserMfaDataSource() datasource.DataSource {
+	return &UserMfaDataSource{}
+}
+
+func (d *UserMfaDataSource) Metadata(_ context.Context, req datasource.MetadataRequest, resp *datasource.MetadataResponse) {
+	resp.TypeName = req.ProviderTypeName + "_user_mfa"
+}
+
+func (d *UserMfaDataSource) Schema(_ context.Context, _ datasource.SchemaRequest, resp *datasource.SchemaResponse) {
+	resp.Schema = schema.Schema{
+		Description:         "Read the MFA status of a RustFS user",
+		MarkdownDescription: "Fetch the second-factor (MFA) status of a RustFS user by access key",
+		Attributes: map[string]schema.Attribute{
+			"access_key": schema.StringAttribute{
+				Required:    true,
+				Description: "Access key of the user.",
+			},
+			"enabled": schema.BoolAttribute{
+				Computed:    true,
+				Description: "Whether two-factor authentication is enabled for the user.",
+			},
+			"activated_at": schema.StringAttribute{
+				Computed:    true,
+				Description: "RFC3339 timestamp of when the second factor was activated, if enabled.",
+			},
+			"recovery_codes_remaining": schema.Int64Attribute{
+				Computed:    true,
+				Description: "Number of unused recovery codes remaining for the user.",
+			},
+		},
+	}
+}
+
+func (d *UserMfaDataSource) Configure(_ context.Context, req datasource.ConfigureRequest, resp *datasource.ConfigureResponse) {
+	if req.ProviderData == nil {
+		return
+	}
+	client, ok := req.ProviderData.(*AllClient)
+	if !ok {
+		resp.Diagnostics.AddError(
+			"Unexpected Data Source Configure Type",
+			fmt.Sprintf("Expected *AllClient, got: %T. Please report this issue to the provider developers.", req.ProviderData),
+		)
+		return
+	}
+	d.client = client
+}
+
+func (d *UserMfaDataSource) Read(ctx context.Context, req datasource.ReadRequest, resp *datasource.ReadResponse) {
+	var config UserMfaDataSourceModel
+	resp.Diagnostics.Append(req.Config.Get(ctx, &config)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	status, err := d.client.RustClient.ReadUserMFA(config.AccessKey.ValueString())
+	if err != nil {
+		resp.Diagnostics.AddError(
+			"Error reading MFA status",
+			"Could not read MFA status: "+err.Error(),
+		)
+		return
+	}
+
+	config.Enabled = types.BoolValue(status.Enabled)
+	config.ActivatedAt = types.StringValue(status.ActivatedAt)
+	config.RecoveryCodesRemaining = types.Int64Value(int64(status.RecoveryCodesRemaining))
+
+	resp.Diagnostics.Append(resp.State.Set(ctx, &config)...)
+}

--- a/provider/rustfs_user_mfa_datasource_test.go
+++ b/provider/rustfs_user_mfa_datasource_test.go
@@ -1,0 +1,68 @@
+package provider
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-framework/datasource"
+	"github.com/hashicorp/terraform-plugin-testing/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+)
+
+func TestUserMfaDataSourceSchema(t *testing.T) {
+	d := NewUserMfaDataSource()
+	resp := &datasource.SchemaResponse{}
+	d.Schema(context.TODO(), datasource.SchemaRequest{}, resp)
+
+	if diags := resp.Diagnostics; diags.HasError() {
+		t.Fatalf("schema diagnostics: %v", diags)
+	}
+
+	attrs := resp.Schema.GetAttributes()
+	for _, want := range []string{"access_key", "enabled", "activated_at", "recovery_codes_remaining"} {
+		if _, ok := attrs[want]; !ok {
+			t.Errorf("expected %s attribute", want)
+		}
+	}
+}
+
+func TestUserMfaDataSourceMetadata(t *testing.T) {
+	d := NewUserMfaDataSource()
+	resp := &datasource.MetadataResponse{}
+	d.Metadata(context.TODO(), datasource.MetadataRequest{ProviderTypeName: "rustfs"}, resp)
+
+	if resp.TypeName != "rustfs_user_mfa" {
+		t.Errorf("expected rustfs_user_mfa, got %s", resp.TypeName)
+	}
+}
+
+func TestAccUserMfaDataSource(t *testing.T) {
+	name := fmt.Sprintf("tf-test-mfa-%d", acctest.RandInt())
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccProviderConfig() + fmt.Sprintf(`
+resource "rustfs_user" "test" {
+  name       = "%s"
+  access_key = "%s"
+  secret_key = "superSecret123!"
+  status     = "enabled"
+  policy     = ""
+}
+
+data "rustfs_user_mfa" "test" {
+  access_key = rustfs_user.test.access_key
+}
+`, name, name),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr("data.rustfs_user_mfa.test", "access_key", name),
+					resource.TestCheckResourceAttrSet("data.rustfs_user_mfa.test", "enabled"),
+				),
+			},
+		},
+	})
+}


### PR DESCRIPTION
**Issue:** https://github.com/weinmann-emt/terraform-provider-rustfs/issues/94

Add a `rustfs_user_mfa` data source exposing a user's MFA/second-factor state.

Closes #94

## Changes
- `pkg/rustfs/mfa.go`: `GetUserMfa` (`GET /rustfs/admin/v3/user/mfa?accessKey=...`).
- `provider/rustfs_user_mfa_datasource.go`, registered in `DataSources()`.
- Unit (httptest) + acceptance tests; docs + example.

## Testing
- `go build`, `go vet`, gofmt clean; golangci-lint no new findings.
- httptest unit tests pass; acceptance test passes against a live RustFS.
