### PR TITLE
feat: add rustfs_ldap_policy_attachment resource (#96)

### DIFF
--- a/docs/resources/ldap_policy_attachment.md
+++ b/docs/resources/ldap_policy_attachment.md
@@ -1,0 +1,72 @@
+---
+page_title: "rustfs_ldap_policy_attachment Resource - rustfs"
+description: |-
+  Attach a canned policy to an LDAP user or group
+---
+
+# rustfs_ldap_policy_attachment (Resource)
+
+Attach a canned policy to an LDAP user or group. The policy is detached when the resource is destroyed.
+
+The target user or group must exist on the RustFS cluster, which requires an LDAP identity provider (IdP) to be configured and the LDAP directory to be synced. Set `is_group = true` to attach to an LDAP group instead of an LDAP user.
+
+## Example Usage
+
+```terraform
+resource "rustfs_ldap_policy_attachment" "alice_readwrite" {
+  user_or_group = "uid=alice,ou=people,dc=example,dc=com"
+  policy        = "readwrite"
+}
+
+resource "rustfs_ldap_policy_attachment" "engineers_readonly" {
+  user_or_group = "cn=engineers,ou=groups,dc=example,dc=com"
+  policy        = "readonly"
+  is_group      = true
+}
+```
+
+## Schema
+
+### Required
+
+- `policy` (String) Name of the canned policy. Changing this forces a new attachment.
+- `user_or_group` (String) LDAP user or group (distinguished name) the policy is attached to. Changing this forces a new attachment.
+
+### Optional
+
+- `is_group` (Boolean) Whether `user_or_group` is an LDAP group. Defaults to `false` (LDAP user).
+
+### Read-Only
+
+- `id` (String) Composite identifier in the form `user_or_group/policy`.
+
+## Import
+
+Import is supported using the composite `<user_or_group>/<policy>` identifier, optionally suffixed with the `is_group` flag:
+
+```
+terraform import rustfs_ldap_policy_attachment.test uid=alice,ou=people,dc=example,dc=com/readwrite
+terraform import rustfs_ldap_policy_attachment.group cn=engineers,ou=groups,dc=example,dc=com/readonly/true
+```
+
+## Acceptance Testing
+
+The acceptance tests require an LDAP identity provider to be configured on the RustFS cluster and the target LDAP user/group to exist. They skip gracefully when no LDAP IdP is configured.
+
+Without an LDAP IdP you can still exercise the API end-to-end by pointing the tests at a regular (builtin) user that exists on the cluster:
+
+```
+# create the user, e.g. via the rustfs_user resource, then:
+RUSTFS_LDAP_POLICY_USER_TARGET=my-test-user \
+  TF_ACC=1 RUSTFS_ENDPOINT=localhost:9001 RUSTFS_USER=rustfsadmin RUSTFS_SECRET=rustfsadmin \
+  go test -v -failfast -timeout 10m ./provider -run "TestAccLdapPolicyAttachment" -count=1
+```
+
+With a configured LDAP IdP, set the target environment variables to real distinguished names instead:
+
+```
+RUSTFS_LDAP_POLICY_USER_TARGET="uid=alice,ou=people,dc=example,dc=com" \
+RUSTFS_LDAP_POLICY_GROUP_TARGET="cn=engineers,ou=groups,dc=example,dc=com" \
+  TF_ACC=1 RUSTFS_ENDPOINT=localhost:9001 RUSTFS_USER=rustfsadmin RUSTFS_SECRET=rustfsadmin \
+  go test -v -failfast -timeout 10m ./provider -run "TestAccLdapPolicyAttachment" -count=1
+```

--- a/examples/resources/rustfs_ldap_policy_attachment/resource.tf
+++ b/examples/resources/rustfs_ldap_policy_attachment/resource.tf
@@ -1,0 +1,4 @@
+resource "rustfs_ldap_policy_attachment" "alice_readwrite" {
+  user_or_group = "uid=alice,ou=people,dc=example,dc=com"
+  policy        = "readwrite"
+}

--- a/pkg/rustfs/ldap_policy.go
+++ b/pkg/rustfs/ldap_policy.go
@@ -1,0 +1,58 @@
+package rustfs
+
+import (
+	"context"
+	"encoding/json"
+)
+
+// LDAPPolicyAttachment identifies a canned policy attached to an LDAP user or
+// group. The RustFS admin API expresses the target via a dedicated field, so
+// the JSON body carries the policy name under "policies" and the distinguished
+// name under either "user" or "group".
+type LDAPPolicyAttachment struct {
+	UserOrGroup string
+	PolicyName  string
+	IsGroup     bool
+}
+
+func (a LDAPPolicyAttachment) MarshalJSON() ([]byte, error) {
+	target := "user"
+	if a.IsGroup {
+		target = "group"
+	}
+	payload := map[string]any{
+		"policies": []string{a.PolicyName},
+		target:     a.UserOrGroup,
+	}
+	return json.Marshal(payload)
+}
+
+// AttachLDAPPolicy attaches a canned policy to an LDAP user or group.
+func (c *RustfsAdmin) AttachLDAPPolicy(req LDAPPolicyAttachment) error {
+	return c.ldapPolicyOperation("attach", req)
+}
+
+// DetachLDAPPolicy detaches a canned policy from an LDAP user or group.
+func (c *RustfsAdmin) DetachLDAPPolicy(req LDAPPolicyAttachment) error {
+	return c.ldapPolicyOperation("detach", req)
+}
+
+func (c *RustfsAdmin) ldapPolicyOperation(operation string, req LDAPPolicyAttachment) error {
+	bytes, err := json.Marshal(req)
+	if err != nil {
+		return err
+	}
+	reqData := RequestData{
+		Method:  "POST",
+		RelPath: "idp/ldap/policy/" + operation,
+		Content: bytes,
+	}
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	resp, err := c.doRequest(ctx, reqData)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+	return nil
+}

--- a/pkg/rustfs/ldap_policy_test.go
+++ b/pkg/rustfs/ldap_policy_test.go
@@ -1,0 +1,140 @@
+package rustfs
+
+import (
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+func TestAttachLdapPolicy(t *testing.T) {
+	var gotPath string
+	var gotBody []byte
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotPath = r.URL.Path + "?" + r.URL.RawQuery
+		gotBody, _ = io.ReadAll(r.Body)
+		if r.Method != http.MethodPost {
+			t.Errorf("expected POST, got %s", r.Method)
+		}
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer server.Close()
+
+	client := New(&RustfsAdminConfig{
+		Endpoint:  server.Listener.Addr().String(),
+		AccessKey: "admin",
+	})
+	client.accessSecret = "secret"
+
+	err := client.AttachLDAPPolicy(LDAPPolicyAttachment{
+		UserOrGroup: "uid=alice,ou=people,dc=example,dc=com",
+		PolicyName:  "readwrite",
+		IsGroup:     false,
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !strings.Contains(gotPath, "/idp/ldap/policy/attach") {
+		t.Errorf("wrong request path: %s", gotPath)
+	}
+
+	var body map[string]any
+	if err := json.Unmarshal(gotBody, &body); err != nil {
+		t.Fatalf("body is not valid JSON: %v", err)
+	}
+	if policies, ok := body["policies"].([]any); !ok || len(policies) != 1 || policies[0] != "readwrite" {
+		t.Errorf("wrong policies in body: %s", gotBody)
+	}
+	if user, ok := body["user"].(string); !ok || user != "uid=alice,ou=people,dc=example,dc=com" {
+		t.Errorf("wrong user in body: %s", gotBody)
+	}
+	if _, hasGroup := body["group"]; hasGroup {
+		t.Errorf("user attachment must not set group: %s", gotBody)
+	}
+}
+
+func TestAttachLdapPolicyGroup(t *testing.T) {
+	var gotBody []byte
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotBody, _ = io.ReadAll(r.Body)
+		if r.Method != http.MethodPost {
+			t.Errorf("expected POST, got %s", r.Method)
+		}
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer server.Close()
+
+	client := New(&RustfsAdminConfig{
+		Endpoint:  server.Listener.Addr().String(),
+		AccessKey: "admin",
+	})
+	client.accessSecret = "secret"
+
+	err := client.AttachLDAPPolicy(LDAPPolicyAttachment{
+		UserOrGroup: "cn=engineers,ou=groups,dc=example,dc=com",
+		PolicyName:  "readwrite",
+		IsGroup:     true,
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	var body map[string]any
+	if err := json.Unmarshal(gotBody, &body); err != nil {
+		t.Fatalf("body is not valid JSON: %v", err)
+	}
+	if policies, ok := body["policies"].([]any); !ok || len(policies) != 1 || policies[0] != "readwrite" {
+		t.Errorf("wrong policies in body: %s", gotBody)
+	}
+	if group, ok := body["group"].(string); !ok || group != "cn=engineers,ou=groups,dc=example,dc=com" {
+		t.Errorf("wrong group in body: %s", gotBody)
+	}
+	if _, hasUser := body["user"]; hasUser {
+		t.Errorf("group attachment must not set user: %s", gotBody)
+	}
+}
+
+func TestDetachLdapPolicy(t *testing.T) {
+	var gotPath string
+	var gotBody []byte
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotPath = r.URL.Path + "?" + r.URL.RawQuery
+		gotBody, _ = io.ReadAll(r.Body)
+		if r.Method != http.MethodPost {
+			t.Errorf("expected POST, got %s", r.Method)
+		}
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer server.Close()
+
+	client := New(&RustfsAdminConfig{
+		Endpoint:  server.Listener.Addr().String(),
+		AccessKey: "admin",
+	})
+	client.accessSecret = "secret"
+
+	err := client.DetachLDAPPolicy(LDAPPolicyAttachment{
+		UserOrGroup: "uid=alice,ou=people,dc=example,dc=com",
+		PolicyName:  "readwrite",
+		IsGroup:     false,
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !strings.Contains(gotPath, "/idp/ldap/policy/detach") {
+		t.Errorf("wrong request path: %s", gotPath)
+	}
+
+	var body map[string]any
+	if err := json.Unmarshal(gotBody, &body); err != nil {
+		t.Fatalf("body is not valid JSON: %v", err)
+	}
+	if policies, ok := body["policies"].([]any); !ok || len(policies) != 1 || policies[0] != "readwrite" {
+		t.Errorf("wrong policies in body: %s", gotBody)
+	}
+	if user, ok := body["user"].(string); !ok || user != "uid=alice,ou=people,dc=example,dc=com" {
+		t.Errorf("wrong user in body: %s", gotBody)
+	}
+}

--- a/provider/provider.go
+++ b/provider/provider.go
@@ -137,6 +137,7 @@ func (p *RustfsProvider) Resources(ctx context.Context) []func() resource.Resour
 		NewBucketReplicationResource,
 		NewBucketEncryptionResource,
 		NewBucketVersioningResource,
+		NewLDAPPolicyAttachmentRessource,
 	}
 }
 

--- a/provider/rustfs_ldap_policy_attachment_ressource.go
+++ b/provider/rustfs_ldap_policy_attachment_ressource.go
@@ -1,0 +1,205 @@
+package provider
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/hashicorp/terraform-plugin-framework/path"
+	"github.com/hashicorp/terraform-plugin-framework/resource"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/booldefault"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/boolplanmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/hashicorp/terraform-plugin-log/tflog"
+	"github.com/weinmann-emt/terraform-provider-rustfs/pkg/rustfs"
+)
+
+var (
+	_ resource.Resource                = &LDAPPolicyAttachmentRessource{}
+	_ resource.ResourceWithImportState = &LDAPPolicyAttachmentRessource{}
+)
+
+type LDAPPolicyAttachmentRessource struct {
+	client *AllClient
+}
+
+type LDAPPolicyAttachmentRessourceModel struct {
+	UserOrGroup types.String `tfsdk:"user_or_group"`
+	Policy      types.String `tfsdk:"policy"`
+	IsGroup     types.Bool   `tfsdk:"is_group"`
+	ID          types.String `tfsdk:"id"`
+}
+
+func NewLDAPPolicyAttachmentRessource() resource.Resource {
+	return &LDAPPolicyAttachmentRessource{}
+}
+
+func (r *LDAPPolicyAttachmentRessource) Metadata(_ context.Context, req resource.MetadataRequest, resp *resource.MetadataResponse) {
+	resp.TypeName = req.ProviderTypeName + "_ldap_policy_attachment"
+}
+
+func (r *LDAPPolicyAttachmentRessource) Schema(_ context.Context, _ resource.SchemaRequest, resp *resource.SchemaResponse) {
+	resp.Schema = schema.Schema{
+		Description:         "Attach a canned policy to an LDAP user or group",
+		MarkdownDescription: "Attach a canned policy to an LDAP user or group and detach it on destroy",
+		Attributes: map[string]schema.Attribute{
+			"user_or_group": schema.StringAttribute{
+				Required:    true,
+				Description: "LDAP user or group (distinguished name) the policy is attached to. Changing this forces a new attachment.",
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.RequiresReplace(),
+				},
+			},
+			"policy": schema.StringAttribute{
+				Required:    true,
+				Description: "Name of the canned policy. Changing this forces a new attachment.",
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.RequiresReplace(),
+				},
+			},
+			"is_group": schema.BoolAttribute{
+				Optional:    true,
+				Computed:    true,
+				Description: "Whether user_or_group is an LDAP group. Defaults to false (LDAP user).",
+				Default:     booldefault.StaticBool(false),
+				PlanModifiers: []planmodifier.Bool{
+					boolplanmodifier.RequiresReplace(),
+				},
+			},
+			"id": schema.StringAttribute{
+				Computed:    true,
+				Description: "Composite identifier in the form user_or_group/policy.",
+			},
+		},
+	}
+}
+
+func (r *LDAPPolicyAttachmentRessource) Configure(_ context.Context, req resource.ConfigureRequest, resp *resource.ConfigureResponse) {
+	if req.ProviderData == nil {
+		return
+	}
+	client, ok := req.ProviderData.(*AllClient)
+	if !ok {
+		resp.Diagnostics.AddError(
+			"Unexpected Resource Configure Type",
+			fmt.Sprintf("Expected *AllClient, got: %T. Please report this issue to the provider developers.", req.ProviderData),
+		)
+		return
+	}
+	r.client = client
+}
+
+func (r *LDAPPolicyAttachmentRessource) Create(ctx context.Context, req resource.CreateRequest, resp *resource.CreateResponse) {
+	var plan LDAPPolicyAttachmentRessourceModel
+	resp.Diagnostics.Append(req.Plan.Get(ctx, &plan)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	err := r.client.RustClient.AttachLDAPPolicy(rustfs.LDAPPolicyAttachment{
+		UserOrGroup: plan.UserOrGroup.ValueString(),
+		PolicyName:  plan.Policy.ValueString(),
+		IsGroup:     plan.IsGroup.ValueBool(),
+	})
+	if err != nil {
+		resp.Diagnostics.AddError(
+			"Error attaching policy to LDAP entity",
+			"Could not attach policy: "+err.Error(),
+		)
+		return
+	}
+
+	plan.ID = types.StringValue(plan.UserOrGroup.ValueString() + "/" + plan.Policy.ValueString())
+	tflog.Trace(ctx, "attached policy to LDAP entity")
+	resp.Diagnostics.Append(resp.State.Set(ctx, &plan)...)
+}
+
+func (r *LDAPPolicyAttachmentRessource) Read(ctx context.Context, req resource.ReadRequest, resp *resource.ReadResponse) {
+	var state LDAPPolicyAttachmentRessourceModel
+	resp.Diagnostics.Append(req.State.Get(ctx, &state)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+	// There is no per-target read-back endpoint for LDAP policy attachments
+	// and the attach operation is idempotent with an immutable natural key,
+	// so the last known state is preserved (same pattern as rustfs_bucket).
+	// The identifier and default are recomputed so imported state round-trips.
+	if state.IsGroup.IsNull() {
+		state.IsGroup = types.BoolValue(false)
+	}
+	state.ID = types.StringValue(state.UserOrGroup.ValueString() + "/" + state.Policy.ValueString())
+	resp.Diagnostics.Append(resp.State.Set(ctx, &state)...)
+}
+
+func (r *LDAPPolicyAttachmentRessource) Update(ctx context.Context, req resource.UpdateRequest, resp *resource.UpdateResponse) {
+	var plan LDAPPolicyAttachmentRessourceModel
+	resp.Diagnostics.Append(req.Plan.Get(ctx, &plan)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+	// All attributes are RequiresReplace, so Terraform normally plans a
+	// replacement; re-attaching keeps this method correct if it is invoked.
+	err := r.client.RustClient.AttachLDAPPolicy(rustfs.LDAPPolicyAttachment{
+		UserOrGroup: plan.UserOrGroup.ValueString(),
+		PolicyName:  plan.Policy.ValueString(),
+		IsGroup:     plan.IsGroup.ValueBool(),
+	})
+	if err != nil {
+		resp.Diagnostics.AddError(
+			"Error attaching policy to LDAP entity",
+			"Could not attach policy: "+err.Error(),
+		)
+		return
+	}
+	plan.ID = types.StringValue(plan.UserOrGroup.ValueString() + "/" + plan.Policy.ValueString())
+	resp.Diagnostics.Append(resp.State.Set(ctx, &plan)...)
+}
+
+func (r *LDAPPolicyAttachmentRessource) Delete(ctx context.Context, req resource.DeleteRequest, resp *resource.DeleteResponse) {
+	var data LDAPPolicyAttachmentRessourceModel
+	resp.Diagnostics.Append(req.State.Get(ctx, &data)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	err := r.client.RustClient.DetachLDAPPolicy(rustfs.LDAPPolicyAttachment{
+		UserOrGroup: data.UserOrGroup.ValueString(),
+		PolicyName:  data.Policy.ValueString(),
+		IsGroup:     data.IsGroup.ValueBool(),
+	})
+	if err != nil {
+		resp.Diagnostics.AddError(
+			"Error detaching policy from LDAP entity",
+			"Could not detach policy: "+err.Error(),
+		)
+		return
+	}
+}
+
+func (r *LDAPPolicyAttachmentRessource) ImportState(ctx context.Context, req resource.ImportStateRequest, resp *resource.ImportStateResponse) {
+	// Accepts "<user_or_group>/<policy>" and optionally
+	// "<user_or_group>/<policy>/<is_group>". The policy is identified from the
+	// right so distinguished names containing "/" are still supported.
+	parts := strings.Split(req.ID, "/")
+	if len(parts) < 2 {
+		resp.Diagnostics.AddError(
+			"Invalid import ID",
+			"Expected format: <user_or_group>/<policy> or <user_or_group>/<policy>/<is_group>",
+		)
+		return
+	}
+	isGroupIdx := -1
+	policyIdx := len(parts) - 1
+	if len(parts) >= 3 && (parts[len(parts)-2] == "true" || parts[len(parts)-2] == "false") {
+		isGroupIdx = len(parts) - 2
+		policyIdx = len(parts) - 2
+	}
+	resp.Diagnostics.Append(resp.State.SetAttribute(ctx, path.Root("user_or_group"), strings.Join(parts[:policyIdx], "/"))...)
+	resp.Diagnostics.Append(resp.State.SetAttribute(ctx, path.Root("policy"), parts[policyIdx])...)
+	if isGroupIdx != -1 {
+		resp.Diagnostics.Append(resp.State.SetAttribute(ctx, path.Root("is_group"), parts[isGroupIdx])...)
+	}
+}

--- a/provider/rustfs_ldap_policy_attachment_ressource_test.go
+++ b/provider/rustfs_ldap_policy_attachment_ressource_test.go
@@ -1,0 +1,123 @@
+package provider
+
+import (
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/weinmann-emt/terraform-provider-rustfs/pkg/rustfs"
+)
+
+const (
+	testAccLdapPolicyUserTargetDefault  = "uid=terraform-acc-test,ou=people,dc=example,dc=com"
+	testAccLdapPolicyGroupTargetDefault = "cn=terraform-acc-test,ou=groups,dc=example,dc=com"
+)
+
+func testAccLdapPolicyUserTarget() string {
+	if v := os.Getenv("RUSTFS_LDAP_POLICY_USER_TARGET"); v != "" {
+		return v
+	}
+	return testAccLdapPolicyUserTargetDefault
+}
+
+func testAccLdapPolicyGroupTarget() string {
+	if v := os.Getenv("RUSTFS_LDAP_POLICY_GROUP_TARGET"); v != "" {
+		return v
+	}
+	return testAccLdapPolicyGroupTargetDefault
+}
+
+// testAccLdapPolicyPreCheck probes the server to confirm the LDAP policy
+// endpoint is reachable and the target user_or_group exists. Without a
+// configured LDAP identity provider (or without the target entity) the attach
+// fails with a "not exist" error, in which case the test skips gracefully.
+func testAccLdapPolicyPreCheck(t *testing.T, target string, isGroup bool) {
+	testAccPreCheck(t)
+	client := rustfs.New(&rustfs.RustfsAdminConfig{
+		Endpoint:     os.Getenv("RUSTFS_ENDPOINT"),
+		AccessKey:    os.Getenv("RUSTFS_USER"),
+		AccessSecret: os.Getenv("RUSTFS_SECRET"),
+		Ssl:          false,
+	})
+	req := rustfs.LDAPPolicyAttachment{
+		UserOrGroup: target,
+		PolicyName:  "readwrite",
+		IsGroup:     isGroup,
+	}
+	if err := client.AttachLDAPPolicy(req); err != nil {
+		if strings.Contains(err.Error(), "not exist") || strings.Contains(err.Error(), "does not exist") {
+			t.Skipf("no LDAP identity provider configured (or target %q does not exist); "+
+				"skipping LDAP policy attachment acceptance test. See docs/resources/ldap_policy_attachment.md "+
+				"on configuring an LDAP IdP or pointing RUSTFS_LDAP_POLICY_USER_TARGET/"+
+				"RUSTFS_LDAP_POLICY_GROUP_TARGET at an existing user/group.", target)
+		}
+		t.Fatalf("unexpected error probing LDAP policy attachment: %v", err)
+	}
+	if err := client.DetachLDAPPolicy(req); err != nil {
+		t.Fatalf("failed to clean up LDAP policy probe: %v", err)
+	}
+}
+
+func TestAccLdapPolicyAttachment_basic(t *testing.T) {
+	target := testAccLdapPolicyUserTarget()
+	resourceName := "rustfs_ldap_policy_attachment.test"
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { testAccLdapPolicyPreCheck(t, target, false) },
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccLdapPolicyAttachmentConfig("test", target, "readwrite", "false"),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceName, "user_or_group", target),
+					resource.TestCheckResourceAttr(resourceName, "policy", "readwrite"),
+					resource.TestCheckResourceAttr(resourceName, "is_group", "false"),
+					resource.TestCheckResourceAttrSet(resourceName, "id"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateId:     target + "/readwrite",
+			},
+		},
+	})
+}
+
+func TestAccLdapPolicyAttachment_group(t *testing.T) {
+	target := testAccLdapPolicyGroupTarget()
+	resourceName := "rustfs_ldap_policy_attachment.group"
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { testAccLdapPolicyPreCheck(t, target, true) },
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccLdapPolicyAttachmentConfig("group", target, "readonly", "true"),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceName, "user_or_group", target),
+					resource.TestCheckResourceAttr(resourceName, "policy", "readonly"),
+					resource.TestCheckResourceAttr(resourceName, "is_group", "true"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateId:     target + "/readonly/true",
+			},
+		},
+	})
+}
+
+func testAccLdapPolicyAttachmentConfig(resourceLabel, target, policy, isGroup string) string {
+	return testAccProviderConfig() + `
+resource "rustfs_ldap_policy_attachment" "` + resourceLabel + `" {
+  user_or_group = "` + target + `"
+  policy        = "` + policy + `"
+  is_group      = ` + isGroup + `
+}
+`
+}


### PR DESCRIPTION
**Issue:** https://github.com/weinmann-emt/terraform-provider-rustfs/issues/96

Add a `rustfs_ldap_policy_attachment` resource to attach/detach a policy to an LDAP user or group.

Closes #96

## Changes
- `pkg/rustfs/ldap_policy.go`: attach/detach via `POST /rustfs/admin/v3/idp/ldap/policy/{operation}` with `{"policies":[...],"user"|"group":...}` (verified against RustFS source + live server).
- `provider/rustfs_ldap_policy_attachment_ressource.go`, registered in `Resources()`.
- Unit (httptest) + acceptance tests; docs + example.

## Testing
- `go build`, `go vet`, gofmt clean; golangci-lint no new findings.
- Unit tests pass; user path verified live; group path skips gracefully without an LDAP IdP.
