### PR TITLE
feat: add rustfs_bucket_tags resource (#101)

### DIFF
--- a/docs/resources/bucket_tags.md
+++ b/docs/resources/bucket_tags.md
@@ -1,0 +1,45 @@
+---
+page_title: "rustfs_bucket_tags Resource - rustfs"
+description: |-
+  Manage the tags on an S3 bucket in rustfs
+---
+
+# rustfs_bucket_tags (Resource)
+
+Manage the tags on an S3 bucket in rustfs.
+
+## Example Usage
+
+```terraform
+resource "rustfs_bucket" "example" {
+  name = "my-tagged-bucket"
+}
+
+resource "rustfs_bucket_tags" "example" {
+  bucket = rustfs_bucket.example.name
+
+  tags = {
+    environment = "production"
+    team        = "platform"
+  }
+}
+```
+
+## Schema
+
+### Required
+
+- `bucket` (String) Name of the bucket. Changing this forces a new resource to be created.
+- `tags` (Map of String) Map of key/value tag pairs to apply to the bucket
+
+### Read-Only
+
+- `id` (String) The bucket name
+
+## Import
+
+Import is supported using the bucket name:
+
+```
+terraform import rustfs_bucket_tags.example my-bucket
+```

--- a/examples/resources/rustfs_bucket_tags/resource.tf
+++ b/examples/resources/rustfs_bucket_tags/resource.tf
@@ -1,0 +1,12 @@
+resource "rustfs_bucket" "example" {
+  name = "my-tagged-bucket"
+}
+
+resource "rustfs_bucket_tags" "example" {
+  bucket = rustfs_bucket.example.name
+
+  tags = {
+    environment = "production"
+    team        = "platform"
+  }
+}

--- a/pkg/rustfs/tags.go
+++ b/pkg/rustfs/tags.go
@@ -1,0 +1,112 @@
+package rustfs
+
+import (
+	"bytes"
+	"context"
+	"encoding/xml"
+	"io"
+	"net/url"
+	"sort"
+)
+
+// bucketTag represents a single key/value tag pair of the S3 tagging XML.
+type bucketTag struct {
+	Key   string `xml:"Key"`
+	Value string `xml:"Value"`
+}
+
+// bucketTagging is the XML document exchanged via the bucket ?tagging sub-resource.
+type bucketTagging struct {
+	XMLName xml.Name    `xml:"Tagging"`
+	TagSet  []bucketTag `xml:"TagSet>Tag"`
+}
+
+func (c *RustfsAdmin) SetBucketTagging(bucket string, tags map[string]string) error {
+	keys := make([]string, 0, len(tags))
+	for k := range tags {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+
+	tagging := bucketTagging{}
+	for _, k := range keys {
+		tagging.TagSet = append(tagging.TagSet, bucketTag{Key: k, Value: tags[k]})
+	}
+
+	var buf bytes.Buffer
+	err := xml.NewEncoder(&buf).Encode(tagging)
+	if err != nil {
+		return err
+	}
+
+	reqData := RequestData{
+		Method:      "PUT",
+		RelPath:     bucket,
+		Content:     buf.Bytes(),
+		QueryValues: url.Values{"tagging": []string{""}},
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	resp, err := c.DoDirectRequest(ctx, reqData)
+	if resp != nil && resp.Body != nil {
+		_ = resp.Body.Close()
+	}
+	return err
+}
+
+func (c *RustfsAdmin) GetBucketTagging(bucket string) (map[string]string, error) {
+	reqData := RequestData{
+		Method:      "GET",
+		RelPath:     bucket,
+		QueryValues: url.Values{"tagging": []string{""}},
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	resp, err := c.DoDirectRequest(ctx, reqData)
+	if err != nil {
+		if resp != nil && resp.Body != nil {
+			_ = resp.Body.Close()
+		}
+		return nil, err
+	}
+	defer resp.Body.Close()
+
+	bodyBytes, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, err
+	}
+
+	var tagging bucketTagging
+	err = xml.Unmarshal(bodyBytes, &tagging)
+	if err != nil {
+		return nil, err
+	}
+
+	tags := make(map[string]string, len(tagging.TagSet))
+	for _, t := range tagging.TagSet {
+		tags[t.Key] = t.Value
+	}
+
+	return tags, nil
+}
+
+func (c *RustfsAdmin) RemoveBucketTagging(bucket string) error {
+	reqData := RequestData{
+		Method:      "DELETE",
+		RelPath:     bucket,
+		QueryValues: url.Values{"tagging": []string{""}},
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	resp, err := c.DoDirectRequest(ctx, reqData)
+	if resp != nil && resp.Body != nil {
+		_ = resp.Body.Close()
+	}
+	return err
+}

--- a/pkg/rustfs/tags_test.go
+++ b/pkg/rustfs/tags_test.go
@@ -1,0 +1,161 @@
+package rustfs
+
+import (
+	"encoding/xml"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+func TestBucketTagsSet(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPut {
+			t.Errorf("expected PUT, got %s", r.Method)
+		}
+		if r.URL.Path != "/test-bucket" {
+			t.Errorf("expected path /test-bucket, got %s", r.URL.Path)
+		}
+		if !r.URL.Query().Has("tagging") {
+			t.Errorf("expected ?tagging query, got %s", r.URL.RawQuery)
+		}
+		body, _ := io.ReadAll(r.Body)
+		var tagging bucketTagging
+		if err := xml.Unmarshal(body, &tagging); err != nil {
+			t.Errorf("expected valid tagging XML, got %s: %v", string(body), err)
+		}
+		if len(tagging.TagSet) != 2 {
+			t.Errorf("expected 2 tags, got %d", len(tagging.TagSet))
+		}
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer server.Close()
+
+	client := New(&RustfsAdminConfig{
+		Endpoint:  server.Listener.Addr().String(),
+		AccessKey: "admin",
+	})
+	client.accessSecret = "secret"
+
+	tags := map[string]string{
+		"environment": "production",
+		"team":        "platform",
+	}
+	err := client.SetBucketTagging("test-bucket", tags)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestBucketTagsSetSortedBody(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, _ := io.ReadAll(r.Body)
+		if !strings.Contains(string(body), "<Key>environment</Key><Value>production</Value>") {
+			t.Errorf("unexpected XML body: %s", string(body))
+		}
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer server.Close()
+
+	client := New(&RustfsAdminConfig{
+		Endpoint:  server.Listener.Addr().String(),
+		AccessKey: "admin",
+	})
+	client.accessSecret = "secret"
+
+	err := client.SetBucketTagging("test-bucket", map[string]string{
+		"team":        "platform",
+		"environment": "production",
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestBucketTagsGet(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodGet {
+			t.Errorf("expected GET, got %s", r.Method)
+		}
+		if r.URL.Path != "/test-bucket" {
+			t.Errorf("expected path /test-bucket, got %s", r.URL.Path)
+		}
+		if !r.URL.Query().Has("tagging") {
+			t.Errorf("expected ?tagging query, got %s", r.URL.RawQuery)
+		}
+		w.Header().Set("Content-Type", "application/xml")
+		w.WriteHeader(http.StatusOK)
+		w.Write([]byte(`<Tagging><TagSet><Tag><Key>environment</Key><Value>production</Value></Tag><Tag><Key>team</Key><Value>platform</Value></Tag></TagSet></Tagging>`))
+	}))
+	defer server.Close()
+
+	client := New(&RustfsAdminConfig{
+		Endpoint:  server.Listener.Addr().String(),
+		AccessKey: "admin",
+	})
+	client.accessSecret = "secret"
+
+	tags, err := client.GetBucketTagging("test-bucket")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(tags) != 2 {
+		t.Fatalf("expected 2 tags, got %d", len(tags))
+	}
+	if tags["environment"] != "production" {
+		t.Errorf("expected environment=production, got %q", tags["environment"])
+	}
+	if tags["team"] != "platform" {
+		t.Errorf("expected team=platform, got %q", tags["team"])
+	}
+}
+
+func TestBucketTagsGetError(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusNotFound)
+		w.Write([]byte(`<Error><Code>NoSuchTagSet</Code><Message>The TagSet does not exist</Message></Error>`))
+	}))
+	defer server.Close()
+
+	client := New(&RustfsAdminConfig{
+		Endpoint:  server.Listener.Addr().String(),
+		AccessKey: "admin",
+	})
+	client.accessSecret = "secret"
+
+	_, err := client.GetBucketTagging("test-bucket")
+	if err == nil {
+		t.Fatal("expected error for NoSuchTagSet, got nil")
+	}
+	if !strings.Contains(err.Error(), "NoSuchTagSet") {
+		t.Errorf("expected NoSuchTagSet in error, got %q", err.Error())
+	}
+}
+
+func TestBucketTagsRemove(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodDelete {
+			t.Errorf("expected DELETE, got %s", r.Method)
+		}
+		if r.URL.Path != "/test-bucket" {
+			t.Errorf("expected path /test-bucket, got %s", r.URL.Path)
+		}
+		if !r.URL.Query().Has("tagging") {
+			t.Errorf("expected ?tagging query, got %s", r.URL.RawQuery)
+		}
+		w.WriteHeader(http.StatusNoContent)
+	}))
+	defer server.Close()
+
+	client := New(&RustfsAdminConfig{
+		Endpoint:  server.Listener.Addr().String(),
+		AccessKey: "admin",
+	})
+	client.accessSecret = "secret"
+
+	err := client.RemoveBucketTagging("test-bucket")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}

--- a/provider/provider.go
+++ b/provider/provider.go
@@ -137,6 +137,7 @@ func (p *RustfsProvider) Resources(ctx context.Context) []func() resource.Resour
 		NewBucketReplicationResource,
 		NewBucketEncryptionResource,
 		NewBucketVersioningResource,
+		NewBucketTagsRessource,
 	}
 }
 

--- a/provider/rustfs_bucket_tags_ressource.go
+++ b/provider/rustfs_bucket_tags_ressource.go
@@ -1,0 +1,203 @@
+package provider
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/hashicorp/terraform-plugin-framework/path"
+	"github.com/hashicorp/terraform-plugin-framework/resource"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/hashicorp/terraform-plugin-log/tflog"
+)
+
+// Ensure the implementation satisfies the expected interfaces.
+var (
+	_ resource.Resource                = &bucketTagsRessource{}
+	_ resource.ResourceWithImportState = &bucketTagsRessource{}
+)
+
+// NewBucketTagsRessource is a helper function to simplify the provider implementation.
+func NewBucketTagsRessource() resource.Resource {
+	return &bucketTagsRessource{}
+}
+
+// bucketTagsRessource is the resource implementation.
+type bucketTagsRessource struct {
+	client *AllClient
+}
+
+type bucketTagsModel struct {
+	Bucket types.String `tfsdk:"bucket"`
+	Id     types.String `tfsdk:"id"`
+	Tags   types.Map    `tfsdk:"tags"`
+}
+
+// Metadata returns the resource type name.
+func (r *bucketTagsRessource) Metadata(_ context.Context, req resource.MetadataRequest, resp *resource.MetadataResponse) {
+	resp.TypeName = req.ProviderTypeName + "_bucket_tags"
+}
+
+// Schema defines the schema for the resource.
+func (r *bucketTagsRessource) Schema(_ context.Context, _ resource.SchemaRequest, resp *resource.SchemaResponse) {
+	resp.Schema = schema.Schema{
+		Description:         "Manage the tags on an S3 bucket in rustfs",
+		MarkdownDescription: "Manage the tags on an S3 bucket in rustfs",
+		Attributes: map[string]schema.Attribute{
+			"bucket": schema.StringAttribute{
+				Required: true,
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.RequiresReplace(),
+				},
+				Description: "Name of the bucket",
+			},
+			"id": schema.StringAttribute{
+				Computed: true,
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.UseStateForUnknown(),
+				},
+				Description: "The bucket name",
+			},
+			"tags": schema.MapAttribute{
+				Required:    true,
+				ElementType: types.StringType,
+				Description: "Map of key/value tag pairs to apply to the bucket",
+			},
+		},
+	}
+}
+
+func (r *bucketTagsRessource) Configure(_ context.Context, req resource.ConfigureRequest, resp *resource.ConfigureResponse) {
+	if req.ProviderData == nil {
+		return
+	}
+	client, ok := req.ProviderData.(*AllClient)
+	if !ok {
+		resp.Diagnostics.AddError(
+			"Unexpected Resource Configure Type",
+			fmt.Sprintf("Expected *AllClient, got: %T. Please report this issue to the provider developers.", req.ProviderData),
+		)
+		return
+	}
+	r.client = client
+}
+
+// Create creates the resource and sets the initial Terraform state.
+func (r *bucketTagsRessource) Create(ctx context.Context, req resource.CreateRequest, resp *resource.CreateResponse) {
+	var plan bucketTagsModel
+	resp.Diagnostics.Append(req.Plan.Get(ctx, &plan)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	tagMap := map[string]string{}
+	resp.Diagnostics.Append(plan.Tags.ElementsAs(ctx, &tagMap, false)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	err := r.client.RustClient.SetBucketTagging(plan.Bucket.ValueString(), tagMap)
+	if err != nil {
+		resp.Diagnostics.AddError(
+			"Error creating bucket tags",
+			"Could not set bucket tagging: "+err.Error(),
+		)
+		return
+	}
+
+	tflog.Trace(ctx, "created a bucket tags resource")
+
+	plan.Id = types.StringValue(plan.Bucket.ValueString())
+	resp.Diagnostics.Append(resp.State.Set(ctx, &plan)...)
+}
+
+// Read refreshes the Terraform state with the latest data.
+func (r *bucketTagsRessource) Read(ctx context.Context, req resource.ReadRequest, resp *resource.ReadResponse) {
+	var state bucketTagsModel
+	resp.Diagnostics.Append(req.State.Get(ctx, &state)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	tagMap, err := r.client.RustClient.GetBucketTagging(state.Bucket.ValueString())
+	if err != nil {
+		if strings.Contains(err.Error(), "NoSuchTagSet") ||
+			strings.Contains(err.Error(), "NoSuchBucket") ||
+			strings.Contains(err.Error(), "404") {
+			resp.State.RemoveResource(ctx)
+			return
+		}
+		resp.Diagnostics.AddError(
+			"Error reading bucket tags",
+			"Could not read bucket tagging: "+err.Error(),
+		)
+		return
+	}
+
+	tags, diags := types.MapValueFrom(ctx, types.StringType, tagMap)
+	resp.Diagnostics.Append(diags...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	state.Tags = tags
+	state.Id = types.StringValue(state.Bucket.ValueString())
+	resp.Diagnostics.Append(resp.State.Set(ctx, &state)...)
+}
+
+// Update updates the resource and sets the updated Terraform state on success.
+func (r *bucketTagsRessource) Update(ctx context.Context, req resource.UpdateRequest, resp *resource.UpdateResponse) {
+	var plan bucketTagsModel
+	resp.Diagnostics.Append(req.Plan.Get(ctx, &plan)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	tagMap := map[string]string{}
+	resp.Diagnostics.Append(plan.Tags.ElementsAs(ctx, &tagMap, false)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	err := r.client.RustClient.SetBucketTagging(plan.Bucket.ValueString(), tagMap)
+	if err != nil {
+		resp.Diagnostics.AddError(
+			"Error updating bucket tags",
+			"Could not set bucket tagging: "+err.Error(),
+		)
+		return
+	}
+
+	plan.Id = types.StringValue(plan.Bucket.ValueString())
+	resp.Diagnostics.Append(resp.State.Set(ctx, &plan)...)
+}
+
+// Delete deletes the resource and removes the Terraform state on success.
+func (r *bucketTagsRessource) Delete(ctx context.Context, req resource.DeleteRequest, resp *resource.DeleteResponse) {
+	var data bucketTagsModel
+	resp.Diagnostics.Append(req.State.Get(ctx, &data)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	err := r.client.RustClient.RemoveBucketTagging(data.Bucket.ValueString())
+	if err != nil {
+		if strings.Contains(err.Error(), "NoSuchTagSet") ||
+			strings.Contains(err.Error(), "NoSuchBucket") ||
+			strings.Contains(err.Error(), "404") {
+			// Already deleted
+			return
+		}
+		resp.Diagnostics.AddError(
+			"Error deleting bucket tags",
+			"Could not remove bucket tagging: "+err.Error(),
+		)
+	}
+}
+
+func (r *bucketTagsRessource) ImportState(ctx context.Context, req resource.ImportStateRequest, resp *resource.ImportStateResponse) {
+	resource.ImportStatePassthroughID(ctx, path.Root("bucket"), req, resp)
+}

--- a/provider/rustfs_bucket_tags_ressource_test.go
+++ b/provider/rustfs_bucket_tags_ressource_test.go
@@ -1,0 +1,77 @@
+package provider
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	fwresource "github.com/hashicorp/terraform-plugin-framework/resource"
+	"github.com/hashicorp/terraform-plugin-testing/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+)
+
+func TestBucketTagsRessourceSchema(t *testing.T) {
+	r := NewBucketTagsRessource()
+	req := fwresource.SchemaRequest{}
+	resp := fwresource.SchemaResponse{}
+	r.Schema(context.Background(), req, &resp)
+
+	for _, want := range []string{"bucket", "id", "tags"} {
+		if _, ok := resp.Schema.Attributes[want]; !ok {
+			t.Errorf("missing attribute %q", want)
+		}
+	}
+}
+
+func TestAccBucketTags_basic(t *testing.T) {
+	name := fmt.Sprintf("tf-test-tags-%d", acctest.RandInt())
+	resourceName := "rustfs_bucket_tags.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		CheckDestroy:             testAccCheckBucketDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccBucketTagsConfig(name, `environment = "production"`, `team        = "platform"`),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceName, "bucket", name),
+					resource.TestCheckResourceAttr(resourceName, "id", name),
+					resource.TestCheckResourceAttr(resourceName, "tags.environment", "production"),
+					resource.TestCheckResourceAttr(resourceName, "tags.team", "platform"),
+				),
+			},
+			{
+				Config: testAccBucketTagsConfig(name, `environment = "staging"`, `costcenter  = "cc-42"`),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceName, "tags.environment", "staging"),
+					resource.TestCheckResourceAttr(resourceName, "tags.costcenter", "cc-42"),
+					resource.TestCheckNoResourceAttr(resourceName, "tags.team"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateId:     name,
+			},
+		},
+	})
+}
+
+func testAccBucketTagsConfig(bucket, tag1, tag2 string) string {
+	return fmt.Sprintf(testAccProviderConfig()+`
+resource "rustfs_bucket" "test_bucket" {
+  name = "%s"
+}
+
+resource "rustfs_bucket_tags" "test" {
+  bucket = rustfs_bucket.test_bucket.name
+
+  tags = {
+    %s
+    %s
+  }
+}
+`, bucket, tag1, tag2)
+}


### PR DESCRIPTION
**Issue:** https://github.com/weinmann-emt/terraform-provider-rustfs/issues/101

Add a `rustfs_bucket_tags` resource to manage tags on a bucket.

Closes #101

## Changes
- `pkg/rustfs/tags.go`: set/get/delete via the custom S3 XML client (`DoDirectRequest`, `?tagging`).
- `provider/rustfs_bucket_tags_ressource.go`, registered in `Resources()`.
- Unit (httptest) + acceptance tests; docs + example.

## Testing
- `go build`, `go vet`, gofmt clean; golangci-lint no new findings.
- 5/5 httptest unit tests + acceptance test pass against a live RustFS.
