### PR TITLE
feat: add rustfs_bucket_policy resource (#102)

### DIFF
--- a/docs/resources/bucket_policy.md
+++ b/docs/resources/bucket_policy.md
@@ -1,0 +1,54 @@
+---
+page_title: "rustfs_bucket_policy Resource - rustfs"
+description: |-
+  Manage the raw S3 bucket policy document in rustfs
+---
+
+# rustfs_bucket_policy (Resource)
+
+Manage the raw S3 bucket policy document in rustfs.
+
+This resource manages a complete, raw S3 bucket policy document. For canned
+(readonly/writeonly/readwrite) policies use `rustfs_policy` instead.
+
+## Example Usage
+
+```terraform
+resource "rustfs_bucket" "example" {
+  name = "example"
+}
+
+resource "rustfs_bucket_policy" "public_read" {
+  bucket = rustfs_bucket.example.name
+
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [{
+      Sid       = "PublicRead"
+      Effect    = "Allow"
+      Principal = { AWS = ["*"] }
+      Action    = ["s3:GetObject"]
+      Resource  = ["arn:aws:s3:::example/*"]
+    }]
+  })
+}
+```
+
+## Schema
+
+### Required
+
+- `bucket` (String) Name of the bucket. Changing this forces a new resource to be created.
+- `policy` (String) Raw S3 bucket policy document as JSON.
+
+### Read-Only
+
+- `id` (String) The bucket name.
+
+## Import
+
+Import is supported using the bucket name:
+
+```
+terraform import rustfs_bucket_policy.example example
+```

--- a/examples/resources/rustfs_bucket_policy/resource.tf
+++ b/examples/resources/rustfs_bucket_policy/resource.tf
@@ -1,0 +1,18 @@
+resource "rustfs_bucket" "example" {
+  name = "example"
+}
+
+resource "rustfs_bucket_policy" "public_read" {
+  bucket = rustfs_bucket.example.name
+
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [{
+      Sid       = "PublicRead"
+      Effect    = "Allow"
+      Principal = { AWS = ["*"] }
+      Action    = ["s3:GetObject"]
+      Resource  = ["arn:aws:s3:::example/*"]
+    }]
+  })
+}

--- a/pkg/rustfs/bucket_policy.go
+++ b/pkg/rustfs/bucket_policy.go
@@ -1,0 +1,80 @@
+package rustfs
+
+import (
+	"context"
+	"io"
+	"net/http"
+	"net/url"
+)
+
+// SetBucketPolicy sets the raw S3 bucket policy document on the bucket via the
+// ?policy sub-resource. An empty policy is rejected (use RemoveBucketPolicy to
+// delete a policy).
+func (c *RustfsAdmin) SetBucketPolicy(bucket, policy string) error {
+	reqData := RequestData{
+		Method:      "PUT",
+		RelPath:     bucket,
+		Content:     []byte(policy),
+		QueryValues: url.Values{"policy": []string{""}},
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	resp, err := c.DoDirectRequest(ctx, reqData)
+	if resp != nil && resp.Body != nil {
+		_ = resp.Body.Close()
+	}
+	return err
+}
+
+// GetBucketPolicy returns the raw S3 bucket policy document. It returns ("",
+// nil) when the bucket has no policy configured.
+func (c *RustfsAdmin) GetBucketPolicy(bucket string) (string, error) {
+	reqData := RequestData{
+		Method:      "GET",
+		RelPath:     bucket,
+		QueryValues: url.Values{"policy": []string{""}},
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	resp, err := c.DoDirectRequest(ctx, reqData)
+	if err != nil {
+		if resp != nil && resp.Body != nil {
+			_ = resp.Body.Close()
+		}
+		// A 404 means the bucket has no policy attached.
+		if resp != nil && resp.StatusCode == http.StatusNotFound {
+			return "", nil
+		}
+		return "", err
+	}
+	defer resp.Body.Close()
+
+	bodyBytes, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return "", err
+	}
+
+	return string(bodyBytes), nil
+}
+
+// RemoveBucketPolicy deletes the bucket policy via the ?policy sub-resource.
+func (c *RustfsAdmin) RemoveBucketPolicy(bucket string) error {
+	reqData := RequestData{
+		Method:      "DELETE",
+		RelPath:     bucket,
+		QueryValues: url.Values{"policy": []string{""}},
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	resp, err := c.DoDirectRequest(ctx, reqData)
+	if resp != nil && resp.Body != nil {
+		_ = resp.Body.Close()
+	}
+	return err
+}

--- a/pkg/rustfs/bucket_policy_test.go
+++ b/pkg/rustfs/bucket_policy_test.go
@@ -1,0 +1,125 @@
+package rustfs_test
+
+import (
+	"fmt"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync"
+	"testing"
+
+	"github.com/weinmann-emt/terraform-provider-rustfs/pkg/rustfs"
+)
+
+const testBucketPolicy = `{"Version":"2012-10-17","Statement":[{"Effect":"Allow","Principal":{"AWS":["*"]},"Action":["s3:GetObject"],"Resource":["arn:aws:s3:::test-bucket/*"]}]}`
+
+func newBucketPolicyTestClient(t *testing.T, handler http.HandlerFunc) *rustfs.RustfsAdmin {
+	t.Helper()
+	srv := httptest.NewServer(handler)
+	t.Cleanup(srv.Close)
+
+	endpoint := strings.TrimPrefix(srv.URL, "http://")
+	config := rustfs.RustfsAdminConfig{
+		AccessKey:    "test",
+		AccessSecret: "test",
+		Endpoint:     endpoint,
+		Ssl:          false,
+	}
+	client := rustfs.New(&config)
+	return &client
+}
+
+func TestBucketPolicySetGetRemove(t *testing.T) {
+	var mu sync.Mutex
+	stored := ""
+
+	server := func(w http.ResponseWriter, r *http.Request) {
+		mu.Lock()
+		defer mu.Unlock()
+
+		if r.URL.Path != "/test-bucket" {
+			t.Errorf("unexpected path %q", r.URL.Path)
+		}
+		if got := r.URL.Query().Get("policy"); got != "" {
+			t.Errorf("expected policy query param, got %q", r.URL.Query().Encode())
+		}
+
+		switch r.Method {
+		case http.MethodPut:
+			body, err := io.ReadAll(r.Body)
+			if err != nil {
+				t.Errorf("read body: %v", err)
+			}
+			stored = strings.TrimSpace(string(body))
+			w.WriteHeader(http.StatusNoContent)
+		case http.MethodGet:
+			if stored == "" {
+				w.WriteHeader(http.StatusNotFound)
+				return
+			}
+			w.Header().Set("Content-Type", "application/json")
+			fmt.Fprint(w, stored)
+		case http.MethodDelete:
+			stored = ""
+			w.WriteHeader(http.StatusNoContent)
+		default:
+			w.WriteHeader(http.StatusMethodNotAllowed)
+		}
+	}
+
+	client := newBucketPolicyTestClient(t, server)
+
+	if err := client.SetBucketPolicy("test-bucket", testBucketPolicy); err != nil {
+		t.Fatalf("SetBucketPolicy: %v", err)
+	}
+
+	got, err := client.GetBucketPolicy("test-bucket")
+	if err != nil {
+		t.Fatalf("GetBucketPolicy: %v", err)
+	}
+	if got != testBucketPolicy {
+		t.Fatalf("GetBucketPolicy = %q, want %q", got, testBucketPolicy)
+	}
+
+	if err := client.RemoveBucketPolicy("test-bucket"); err != nil {
+		t.Fatalf("RemoveBucketPolicy: %v", err)
+	}
+
+	got, err = client.GetBucketPolicy("test-bucket")
+	if err != nil {
+		t.Fatalf("GetBucketPolicy after remove: %v", err)
+	}
+	if got != "" {
+		t.Fatalf("GetBucketPolicy after remove = %q, want empty", got)
+	}
+}
+
+func TestBucketPolicyGetWhenNoneExists(t *testing.T) {
+	server := func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusNotFound)
+	}
+
+	client := newBucketPolicyTestClient(t, server)
+
+	got, err := client.GetBucketPolicy("missing-bucket")
+	if err != nil {
+		t.Fatalf("GetBucketPolicy: %v", err)
+	}
+	if got != "" {
+		t.Fatalf("GetBucketPolicy = %q, want empty for missing policy", got)
+	}
+}
+
+func TestBucketPolicySetError(t *testing.T) {
+	server := func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusForbidden)
+		fmt.Fprint(w, "access denied")
+	}
+
+	client := newBucketPolicyTestClient(t, server)
+
+	if err := client.SetBucketPolicy("test-bucket", testBucketPolicy); err == nil {
+		t.Fatal("expected SetBucketPolicy to return an error for 403")
+	}
+}

--- a/provider/provider.go
+++ b/provider/provider.go
@@ -125,6 +125,7 @@ func (p *RustfsProvider) Resources(ctx context.Context) []func() resource.Resour
 		NewPolicyRessource,
 		NewServiceAccountRessource,
 		NewBucketRessource,
+		NewBucketPolicyRessource,
 		NewquotaRessource,
 		NewIamBackupImportResource,
 		NewBucketMetadataBackupImportResource,

--- a/provider/rustfs_bucket_policy_ressource.go
+++ b/provider/rustfs_bucket_policy_ressource.go
@@ -1,0 +1,166 @@
+package provider
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/hashicorp/terraform-plugin-framework/path"
+	"github.com/hashicorp/terraform-plugin-framework/resource"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/hashicorp/terraform-plugin-log/tflog"
+)
+
+var (
+	_ resource.Resource                = &bucketPolicyRessource{}
+	_ resource.ResourceWithImportState = &bucketPolicyRessource{}
+)
+
+func NewBucketPolicyRessource() resource.Resource {
+	return &bucketPolicyRessource{}
+}
+
+type bucketPolicyRessource struct {
+	client *AllClient
+}
+
+type bucketPolicyModel struct {
+	Bucket types.String `tfsdk:"bucket"`
+	Id     types.String `tfsdk:"id"`
+	Policy types.String `tfsdk:"policy"`
+}
+
+func (r *bucketPolicyRessource) Metadata(_ context.Context, req resource.MetadataRequest, resp *resource.MetadataResponse) {
+	resp.TypeName = req.ProviderTypeName + "_bucket_policy"
+}
+
+func (r *bucketPolicyRessource) Schema(_ context.Context, _ resource.SchemaRequest, resp *resource.SchemaResponse) {
+	resp.Schema = schema.Schema{
+		Description:         "Manage the raw S3 bucket policy document in rustfs",
+		MarkdownDescription: "Manage the raw S3 bucket policy document in rustfs",
+		Attributes: map[string]schema.Attribute{
+			"bucket": schema.StringAttribute{
+				Required: true,
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.RequiresReplace(),
+				},
+				Description: "Name of the bucket",
+			},
+			"id": schema.StringAttribute{
+				Computed: true,
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.UseStateForUnknown(),
+				},
+				Description: "The bucket name",
+			},
+			"policy": schema.StringAttribute{
+				Required:    true,
+				Description: "Raw S3 bucket policy document as JSON (see https://docs.aws.amazon.com/AmazonS3/latest/userguide/access-policy-language-overview.html)",
+			},
+		},
+	}
+}
+
+func (r *bucketPolicyRessource) Configure(_ context.Context, req resource.ConfigureRequest, resp *resource.ConfigureResponse) {
+	if req.ProviderData == nil {
+		return
+	}
+	client, ok := req.ProviderData.(*AllClient)
+	if !ok {
+		resp.Diagnostics.AddError(
+			"Unexpected Resource Configure Type",
+			fmt.Sprintf("Expected *AllClient, got: %T. Please report this issue to the provider developers.", req.ProviderData),
+		)
+		return
+	}
+	r.client = client
+}
+
+func (r *bucketPolicyRessource) Create(ctx context.Context, req resource.CreateRequest, resp *resource.CreateResponse) {
+	var plan bucketPolicyModel
+	resp.Diagnostics.Append(req.Plan.Get(ctx, &plan)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	err := r.client.RustClient.SetBucketPolicy(plan.Bucket.ValueString(), plan.Policy.ValueString())
+	if err != nil {
+		resp.Diagnostics.AddError(
+			"Error creating bucket policy",
+			"Could not set bucket policy: "+err.Error(),
+		)
+		return
+	}
+
+	tflog.Trace(ctx, "created a bucket policy resource")
+
+	plan.Id = types.StringValue(plan.Bucket.ValueString())
+	resp.Diagnostics.Append(resp.State.Set(ctx, &plan)...)
+}
+
+func (r *bucketPolicyRessource) Read(ctx context.Context, req resource.ReadRequest, resp *resource.ReadResponse) {
+	var state bucketPolicyModel
+	resp.Diagnostics.Append(req.State.Get(ctx, &state)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	policy, err := r.client.RustClient.GetBucketPolicy(state.Bucket.ValueString())
+	if err != nil {
+		resp.Diagnostics.AddError(
+			"Error reading bucket policy",
+			"Could not read bucket policy: "+err.Error(),
+		)
+		return
+	}
+	if policy == "" {
+		resp.State.RemoveResource(ctx)
+		return
+	}
+
+	state.Policy = types.StringValue(policy)
+	state.Id = types.StringValue(state.Bucket.ValueString())
+	resp.Diagnostics.Append(resp.State.Set(ctx, &state)...)
+}
+
+func (r *bucketPolicyRessource) Update(ctx context.Context, req resource.UpdateRequest, resp *resource.UpdateResponse) {
+	var plan bucketPolicyModel
+	resp.Diagnostics.Append(req.Plan.Get(ctx, &plan)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	err := r.client.RustClient.SetBucketPolicy(plan.Bucket.ValueString(), plan.Policy.ValueString())
+	if err != nil {
+		resp.Diagnostics.AddError(
+			"Error updating bucket policy",
+			"Could not set bucket policy: "+err.Error(),
+		)
+		return
+	}
+
+	plan.Id = types.StringValue(plan.Bucket.ValueString())
+	resp.Diagnostics.Append(resp.State.Set(ctx, plan)...)
+}
+
+func (r *bucketPolicyRessource) Delete(ctx context.Context, req resource.DeleteRequest, resp *resource.DeleteResponse) {
+	var data bucketPolicyModel
+	resp.Diagnostics.Append(req.State.Get(ctx, &data)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	err := r.client.RustClient.RemoveBucketPolicy(data.Bucket.ValueString())
+	if err != nil {
+		resp.Diagnostics.AddError(
+			"Error deleting bucket policy",
+			"Could not remove bucket policy: "+err.Error(),
+		)
+	}
+}
+
+func (r *bucketPolicyRessource) ImportState(ctx context.Context, req resource.ImportStateRequest, resp *resource.ImportStateResponse) {
+	resource.ImportStatePassthroughID(ctx, path.Root("bucket"), req, resp)
+}

--- a/provider/rustfs_bucket_policy_ressource_test.go
+++ b/provider/rustfs_bucket_policy_ressource_test.go
@@ -1,0 +1,80 @@
+package provider
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	frameworkresource "github.com/hashicorp/terraform-plugin-framework/resource"
+	"github.com/hashicorp/terraform-plugin-testing/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+)
+
+func TestBucketPolicyRessourceSchema(t *testing.T) {
+	r := NewBucketPolicyRessource()
+	req := frameworkresource.SchemaRequest{}
+	resp := frameworkresource.SchemaResponse{}
+	r.Schema(context.Background(), req, &resp)
+
+	for _, want := range []string{"bucket", "id", "policy"} {
+		if _, ok := resp.Schema.Attributes[want]; !ok {
+			t.Errorf("missing attribute %q", want)
+		}
+	}
+}
+
+func TestAccBucketPolicyResource(t *testing.T) {
+	bucketName := fmt.Sprintf("tf-test-policy-bucket-%d", acctest.RandInt())
+	resourceName := "rustfs_bucket_policy.test"
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccBucketPolicyConfig(bucketName, "PublicRead", "s3:GetObject"),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceName, "bucket", bucketName),
+					resource.TestCheckResourceAttr(resourceName, "id", bucketName),
+					resource.TestCheckResourceAttrSet(resourceName, "policy"),
+				),
+			},
+			{
+				Config: testAccBucketPolicyConfig(bucketName, "WriteOnly", "s3:PutObject"),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceName, "bucket", bucketName),
+					resource.TestCheckResourceAttrSet(resourceName, "policy"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateId:     bucketName,
+			},
+		},
+	})
+}
+
+func testAccBucketPolicyConfig(bucketName, sid, action string) string {
+	return testAccProviderConfig() + fmt.Sprintf(`
+resource "rustfs_bucket" "test" {
+  name = %q
+}
+
+resource "rustfs_bucket_policy" "test" {
+  bucket = rustfs_bucket.test.name
+
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [{
+      Sid       = %q
+      Effect    = "Allow"
+      Principal = { AWS = ["*"] }
+      Action    = [%q]
+      Resource  = ["arn:aws:s3:::%s/*"]
+    }]
+  })
+}
+`, bucketName, sid, action, bucketName)
+}


### PR DESCRIPTION
**Issue:** https://github.com/weinmann-emt/terraform-provider-rustfs/issues/102

Add a `rustfs_bucket_policy` resource for the bucket's raw S3 policy document (distinct from the canned-policy `rustfs_policy` resource).

Closes #102

## Changes
- `pkg/rustfs/bucket_policy.go`: set/get/delete via `DoDirectRequest` on the S3 `?policy` sub-resource (minio-go v7.0.63 has `SetBucketPolicy`/`GetBucketPolicy` but no exported `RemoveBucketPolicy`; delete = set empty).
- `provider/rustfs_bucket_policy_ressource.go`, registered in `Resources()`.
- Unit (httptest) + acceptance tests; docs + example.

## Testing
- `go build`, `go vet`, gofmt clean; golangci-lint no new findings.
- 3/3 httptest unit tests + acceptance test (full CRUD + import) pass against a live RustFS.
