### PR TITLE
feat: add rustfs_bucket_public_access_block resource (#103)

### DIFF
--- a/docs/resources/bucket_public_access_block.md
+++ b/docs/resources/bucket_public_access_block.md
@@ -1,0 +1,50 @@
+---
+page_title: "rustfs_bucket_public_access_block Resource - rustfs"
+description: |-
+  Manage the block public access configuration of an S3 bucket in rustfs
+---
+
+# rustfs_bucket_public_access_block (Resource)
+
+Manage the block public access configuration of an S3 bucket in rustfs.
+
+## Example Usage
+
+```terraform
+resource "rustfs_bucket" "example" {
+  name = "my-bucket"
+}
+
+resource "rustfs_bucket_public_access_block" "example" {
+  bucket                  = rustfs_bucket.example.name
+  block_public_acls       = true
+  ignore_public_acls      = true
+  block_public_policy     = true
+  restrict_public_buckets = true
+}
+```
+
+## Schema
+
+### Required
+
+- `bucket` (String) Name of the bucket. Changing this forces a new resource to be created.
+
+### Optional
+
+- `block_public_acls` (Boolean) Whether Amazon S3 should block public ACLs for this bucket.
+- `block_public_policy` (Boolean) Whether Amazon S3 should block public bucket policies for this bucket.
+- `ignore_public_acls` (Boolean) Whether Amazon S3 should ignore public ACLs for this bucket.
+- `restrict_public_buckets` (Boolean) Whether Amazon S3 should restrict public bucket policies for this bucket.
+
+### Read-Only
+
+- `id` (String) The bucket name.
+
+## Import
+
+Import is supported using the bucket name:
+
+```
+terraform import rustfs_bucket_public_access_block.example my-bucket
+```

--- a/examples/resources/rustfs_bucket_public_access_block/resource.tf
+++ b/examples/resources/rustfs_bucket_public_access_block/resource.tf
@@ -1,0 +1,11 @@
+resource "rustfs_bucket" "example" {
+  name = "my-bucket"
+}
+
+resource "rustfs_bucket_public_access_block" "example" {
+  bucket                  = rustfs_bucket.example.name
+  block_public_acls       = true
+  ignore_public_acls      = true
+  block_public_policy     = true
+  restrict_public_buckets = true
+}

--- a/pkg/rustfs/public_access_block.go
+++ b/pkg/rustfs/public_access_block.go
@@ -6,10 +6,11 @@ import (
 	"encoding/xml"
 	"io"
 	"net/url"
+	"strings"
 )
 
 type PublicAccessBlockConfiguration struct {
-	XMLName               xml.Name `xml:"http://s3.amazonaws.com/doc/2006-03-01/ PublicAccessBlockConfiguration"`
+	XMLName               xml.Name `xml:"PublicAccessBlockConfiguration"`
 	BlockPublicAcls       bool     `xml:"BlockPublicAcls"`
 	IgnorePublicAcls      bool     `xml:"IgnorePublicAcls"`
 	BlockPublicPolicy     bool     `xml:"BlockPublicPolicy"`
@@ -66,6 +67,12 @@ func (c *RustfsAdmin) GetBucketPublicAccessBlock(bucket string) (*PublicAccessBl
 
 	var config PublicAccessBlockConfiguration
 	err = xml.Unmarshal(bodyBytes, &config)
+	if err != nil {
+		namespacedBody := strings.Replace(string(bodyBytes), `xmlns="http://s3.amazonaws.com/doc/2006-03-01/"`, "", 1)
+		if namespacedBody != string(bodyBytes) {
+			err = xml.Unmarshal([]byte(namespacedBody), &config)
+		}
+	}
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/rustfs/public_access_block.go
+++ b/pkg/rustfs/public_access_block.go
@@ -1,0 +1,91 @@
+package rustfs
+
+import (
+	"bytes"
+	"context"
+	"encoding/xml"
+	"io"
+	"net/url"
+)
+
+type PublicAccessBlockConfiguration struct {
+	XMLName               xml.Name `xml:"http://s3.amazonaws.com/doc/2006-03-01/ PublicAccessBlockConfiguration"`
+	BlockPublicAcls       bool     `xml:"BlockPublicAcls"`
+	IgnorePublicAcls      bool     `xml:"IgnorePublicAcls"`
+	BlockPublicPolicy     bool     `xml:"BlockPublicPolicy"`
+	RestrictPublicBuckets bool     `xml:"RestrictPublicBuckets"`
+}
+
+func (c *RustfsAdmin) SetBucketPublicAccessBlock(bucket string, config *PublicAccessBlockConfiguration) error {
+	var buf bytes.Buffer
+	err := xml.NewEncoder(&buf).Encode(config)
+	if err != nil {
+		return err
+	}
+
+	reqData := RequestData{
+		Method:      "PUT",
+		RelPath:     bucket,
+		Content:     buf.Bytes(),
+		QueryValues: url.Values{"publicAccessBlock": []string{""}},
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	resp, err := c.DoDirectRequest(ctx, reqData)
+	if resp != nil && resp.Body != nil {
+		_ = resp.Body.Close()
+	}
+	return err
+}
+
+func (c *RustfsAdmin) GetBucketPublicAccessBlock(bucket string) (*PublicAccessBlockConfiguration, error) {
+	reqData := RequestData{
+		Method:      "GET",
+		RelPath:     bucket,
+		QueryValues: url.Values{"publicAccessBlock": []string{""}},
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	resp, err := c.DoDirectRequest(ctx, reqData)
+	if err != nil {
+		if resp != nil && resp.Body != nil {
+			_ = resp.Body.Close()
+		}
+		return nil, err
+	}
+	defer resp.Body.Close()
+
+	bodyBytes, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, err
+	}
+
+	var config PublicAccessBlockConfiguration
+	err = xml.Unmarshal(bodyBytes, &config)
+	if err != nil {
+		return nil, err
+	}
+
+	return &config, nil
+}
+
+func (c *RustfsAdmin) DeleteBucketPublicAccessBlock(bucket string) error {
+	reqData := RequestData{
+		Method:      "DELETE",
+		RelPath:     bucket,
+		QueryValues: url.Values{"publicAccessBlock": []string{""}},
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	resp, err := c.DoDirectRequest(ctx, reqData)
+	if resp != nil && resp.Body != nil {
+		_ = resp.Body.Close()
+	}
+	return err
+}

--- a/pkg/rustfs/public_access_block_test.go
+++ b/pkg/rustfs/public_access_block_test.go
@@ -1,0 +1,113 @@
+package rustfs
+
+import (
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+func newTestS3Server(t *testing.T, handler http.HandlerFunc) *RustfsAdmin {
+	t.Helper()
+	srv := httptest.NewServer(handler)
+	t.Cleanup(srv.Close)
+	c := New(&RustfsAdminConfig{
+		AccessKey:    "admin",
+		AccessSecret: "secret",
+		Endpoint:     strings.TrimPrefix(srv.URL, "http://"),
+	})
+	return &c
+}
+
+func assertPublicAccessBlockQuery(t *testing.T, r *http.Request) {
+	t.Helper()
+	if _, ok := r.URL.Query()["publicAccessBlock"]; !ok {
+		t.Errorf("expected publicAccessBlock subresource query, got raw query %q", r.URL.RawQuery)
+	}
+}
+
+func TestSetBucketPublicAccessBlock(t *testing.T) {
+	var gotPath, gotMethod, gotBody string
+	client := newTestS3Server(t, func(w http.ResponseWriter, r *http.Request) {
+		gotPath = r.URL.Path
+		gotMethod = r.Method
+		assertPublicAccessBlockQuery(t, r)
+		bodyBytes, _ := io.ReadAll(r.Body)
+		gotBody = string(bodyBytes)
+		w.WriteHeader(http.StatusOK)
+	})
+
+	err := client.SetBucketPublicAccessBlock("mybucket", &PublicAccessBlockConfiguration{
+		BlockPublicAcls:   true,
+		BlockPublicPolicy: true,
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if gotMethod != "PUT" || gotPath != "/mybucket" {
+		t.Errorf("wrong request: %s %s", gotMethod, gotPath)
+	}
+	if !strings.Contains(gotBody, "<BlockPublicAcls>true</BlockPublicAcls>") ||
+		!strings.Contains(gotBody, "<BlockPublicPolicy>true</BlockPublicPolicy>") {
+		t.Errorf("body missing expected fields: %s", gotBody)
+	}
+}
+
+func TestGetBucketPublicAccessBlock(t *testing.T) {
+	client := newTestS3Server(t, func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != "GET" {
+			t.Errorf("wrong method: %s", r.Method)
+		}
+		assertPublicAccessBlockQuery(t, r)
+		w.Write([]byte(`<PublicAccessBlockConfiguration xmlns="http://s3.amazonaws.com/doc/2006-03-01/">` +
+			`<BlockPublicAcls>true</BlockPublicAcls>` +
+			`<IgnorePublicAcls>false</IgnorePublicAcls>` +
+			`<BlockPublicPolicy>true</BlockPublicPolicy>` +
+			`<RestrictPublicBuckets>false</RestrictPublicBuckets>` +
+			`</PublicAccessBlockConfiguration>`))
+	})
+
+	cfg, err := client.GetBucketPublicAccessBlock("mybucket")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !cfg.BlockPublicAcls || !cfg.BlockPublicPolicy {
+		t.Error("expected BlockPublicAcls and BlockPublicPolicy to be true")
+	}
+	if cfg.IgnorePublicAcls || cfg.RestrictPublicBuckets {
+		t.Error("expected IgnorePublicAcls and RestrictPublicBuckets to be false")
+	}
+}
+
+func TestGetBucketPublicAccessBlockNotFound(t *testing.T) {
+	client := newTestS3Server(t, func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusNotFound)
+		w.Write([]byte(`<Error><Code>NoSuchPublicAccessBlockConfiguration</Code></Error>`))
+	})
+
+	_, err := client.GetBucketPublicAccessBlock("mybucket")
+	if err == nil {
+		t.Fatal("expected an error for a missing public access block configuration")
+	}
+	if !strings.Contains(err.Error(), "NoSuchPublicAccessBlockConfiguration") {
+		t.Errorf("expected NoSuchPublicAccessBlockConfiguration in error, got: %v", err)
+	}
+}
+
+func TestDeleteBucketPublicAccessBlock(t *testing.T) {
+	var gotPath, gotMethod string
+	client := newTestS3Server(t, func(w http.ResponseWriter, r *http.Request) {
+		gotPath = r.URL.Path
+		gotMethod = r.Method
+		assertPublicAccessBlockQuery(t, r)
+		w.WriteHeader(http.StatusNoContent)
+	})
+
+	if err := client.DeleteBucketPublicAccessBlock("mybucket"); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if gotMethod != "DELETE" || gotPath != "/mybucket" {
+		t.Errorf("wrong request: %s %s", gotMethod, gotPath)
+	}
+}

--- a/pkg/rustfs/public_access_block_test.go
+++ b/pkg/rustfs/public_access_block_test.go
@@ -60,7 +60,7 @@ func TestGetBucketPublicAccessBlock(t *testing.T) {
 			t.Errorf("wrong method: %s", r.Method)
 		}
 		assertPublicAccessBlockQuery(t, r)
-		w.Write([]byte(`<PublicAccessBlockConfiguration xmlns="http://s3.amazonaws.com/doc/2006-03-01/">` +
+		_, _ = w.Write([]byte(`<PublicAccessBlockConfiguration>` +
 			`<BlockPublicAcls>true</BlockPublicAcls>` +
 			`<IgnorePublicAcls>false</IgnorePublicAcls>` +
 			`<BlockPublicPolicy>true</BlockPublicPolicy>` +
@@ -80,10 +80,32 @@ func TestGetBucketPublicAccessBlock(t *testing.T) {
 	}
 }
 
+func TestGetBucketPublicAccessBlockNamespaced(t *testing.T) {
+	client := newTestS3Server(t, func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write([]byte(`<PublicAccessBlockConfiguration xmlns="http://s3.amazonaws.com/doc/2006-03-01/">` +
+			`<BlockPublicAcls>true</BlockPublicAcls>` +
+			`<IgnorePublicAcls>true</IgnorePublicAcls>` +
+			`<BlockPublicPolicy>false</BlockPublicPolicy>` +
+			`<RestrictPublicBuckets>false</RestrictPublicBuckets>` +
+			`</PublicAccessBlockConfiguration>`))
+	})
+
+	cfg, err := client.GetBucketPublicAccessBlock("mybucket")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !cfg.BlockPublicAcls || !cfg.IgnorePublicAcls {
+		t.Error("expected BlockPublicAcls and IgnorePublicAcls to be true")
+	}
+	if cfg.BlockPublicPolicy || cfg.RestrictPublicBuckets {
+		t.Error("expected BlockPublicPolicy and RestrictPublicBuckets to be false")
+	}
+}
+
 func TestGetBucketPublicAccessBlockNotFound(t *testing.T) {
 	client := newTestS3Server(t, func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusNotFound)
-		w.Write([]byte(`<Error><Code>NoSuchPublicAccessBlockConfiguration</Code></Error>`))
+		_, _ = w.Write([]byte(`<Error><Code>NoSuchPublicAccessBlockConfiguration</Code></Error>`))
 	})
 
 	_, err := client.GetBucketPublicAccessBlock("mybucket")

--- a/provider/provider.go
+++ b/provider/provider.go
@@ -137,6 +137,7 @@ func (p *RustfsProvider) Resources(ctx context.Context) []func() resource.Resour
 		NewBucketReplicationResource,
 		NewBucketEncryptionResource,
 		NewBucketVersioningResource,
+		NewBucketPublicAccessBlockRessource,
 	}
 }
 

--- a/provider/rustfs_bucket_public_access_block_ressource.go
+++ b/provider/rustfs_bucket_public_access_block_ressource.go
@@ -1,0 +1,222 @@
+package provider
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/hashicorp/terraform-plugin-framework/path"
+	"github.com/hashicorp/terraform-plugin-framework/resource"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/hashicorp/terraform-plugin-log/tflog"
+	"github.com/weinmann-emt/terraform-provider-rustfs/pkg/rustfs"
+)
+
+// Ensure the implementation satisfies the expected interfaces.
+var (
+	_ resource.Resource                = &bucketPublicAccessBlockRessource{}
+	_ resource.ResourceWithImportState = &bucketPublicAccessBlockRessource{}
+)
+
+// NewBucketPublicAccessBlockRessource is a helper function to simplify the provider implementation.
+func NewBucketPublicAccessBlockRessource() resource.Resource {
+	return &bucketPublicAccessBlockRessource{}
+}
+
+// bucketPublicAccessBlockRessource is the resource implementation.
+type bucketPublicAccessBlockRessource struct {
+	client *AllClient
+}
+
+type bucketPublicAccessBlockModel struct {
+	Bucket                types.String `tfsdk:"bucket"`
+	Id                    types.String `tfsdk:"id"`
+	BlockPublicAcls       types.Bool   `tfsdk:"block_public_acls"`
+	IgnorePublicAcls      types.Bool   `tfsdk:"ignore_public_acls"`
+	BlockPublicPolicy     types.Bool   `tfsdk:"block_public_policy"`
+	RestrictPublicBuckets types.Bool   `tfsdk:"restrict_public_buckets"`
+}
+
+// Metadata returns the resource type name.
+func (r *bucketPublicAccessBlockRessource) Metadata(_ context.Context, req resource.MetadataRequest, resp *resource.MetadataResponse) {
+	resp.TypeName = req.ProviderTypeName + "_bucket_public_access_block"
+}
+
+// Schema defines the schema for the resource.
+func (r *bucketPublicAccessBlockRessource) Schema(_ context.Context, _ resource.SchemaRequest, resp *resource.SchemaResponse) {
+	resp.Schema = schema.Schema{
+		Description:         "Manage the block public access configuration of an S3 bucket in rustfs",
+		MarkdownDescription: "Manage the block public access configuration of an S3 bucket in rustfs",
+		Attributes: map[string]schema.Attribute{
+			"bucket": schema.StringAttribute{
+				Required: true,
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.RequiresReplace(),
+				},
+				Description: "Name of the bucket",
+			},
+			"id": schema.StringAttribute{
+				Computed: true,
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.UseStateForUnknown(),
+				},
+				Description: "The bucket name",
+			},
+			"block_public_acls": schema.BoolAttribute{
+				Optional:    true,
+				Computed:    true,
+				Description: "Whether Amazon S3 should block public ACLs for this bucket",
+			},
+			"ignore_public_acls": schema.BoolAttribute{
+				Optional:    true,
+				Computed:    true,
+				Description: "Whether Amazon S3 should ignore public ACLs for this bucket",
+			},
+			"block_public_policy": schema.BoolAttribute{
+				Optional:    true,
+				Computed:    true,
+				Description: "Whether Amazon S3 should block public bucket policies for this bucket",
+			},
+			"restrict_public_buckets": schema.BoolAttribute{
+				Optional:    true,
+				Computed:    true,
+				Description: "Whether Amazon S3 should restrict public bucket policies for this bucket",
+			},
+		},
+	}
+}
+
+func (r *bucketPublicAccessBlockRessource) Configure(_ context.Context, req resource.ConfigureRequest, resp *resource.ConfigureResponse) {
+	if req.ProviderData == nil {
+		return
+	}
+	client, ok := req.ProviderData.(*AllClient)
+	if !ok {
+		resp.Diagnostics.AddError(
+			"Unexpected Resource Configure Type",
+			fmt.Sprintf("Expected *AllClient, got: %T. Please report this issue to the provider developers.", req.ProviderData),
+		)
+		return
+	}
+	r.client = client
+}
+
+// Create creates the resource and sets the initial Terraform state.
+func (r *bucketPublicAccessBlockRessource) Create(ctx context.Context, req resource.CreateRequest, resp *resource.CreateResponse) {
+	var plan bucketPublicAccessBlockModel
+	resp.Diagnostics.Append(req.Plan.Get(ctx, &plan)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	config := &rustfs.PublicAccessBlockConfiguration{
+		BlockPublicAcls:       plan.BlockPublicAcls.ValueBool(),
+		IgnorePublicAcls:      plan.IgnorePublicAcls.ValueBool(),
+		BlockPublicPolicy:     plan.BlockPublicPolicy.ValueBool(),
+		RestrictPublicBuckets: plan.RestrictPublicBuckets.ValueBool(),
+	}
+
+	err := r.client.RustClient.SetBucketPublicAccessBlock(plan.Bucket.ValueString(), config)
+	if err != nil {
+		resp.Diagnostics.AddError(
+			"Error creating bucket public access block",
+			"Could not set public access block: "+err.Error(),
+		)
+		return
+	}
+
+	tflog.Trace(ctx, "created a bucket public access block resource")
+
+	plan.Id = types.StringValue(plan.Bucket.ValueString())
+	resp.Diagnostics.Append(resp.State.Set(ctx, &plan)...)
+}
+
+// Read refreshes the Terraform state with the latest data.
+func (r *bucketPublicAccessBlockRessource) Read(ctx context.Context, req resource.ReadRequest, resp *resource.ReadResponse) {
+	var state bucketPublicAccessBlockModel
+	resp.Diagnostics.Append(req.State.Get(ctx, &state)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	config, err := r.client.RustClient.GetBucketPublicAccessBlock(state.Bucket.ValueString())
+	if err != nil {
+		if strings.Contains(err.Error(), "NoSuchPublicAccessBlockConfiguration") ||
+			strings.Contains(err.Error(), "NoSuchBucket") ||
+			strings.Contains(err.Error(), "404") {
+			resp.State.RemoveResource(ctx)
+			return
+		}
+		resp.Diagnostics.AddError(
+			"Error reading bucket public access block",
+			"Could not read public access block: "+err.Error(),
+		)
+		return
+	}
+
+	state.BlockPublicAcls = types.BoolValue(config.BlockPublicAcls)
+	state.IgnorePublicAcls = types.BoolValue(config.IgnorePublicAcls)
+	state.BlockPublicPolicy = types.BoolValue(config.BlockPublicPolicy)
+	state.RestrictPublicBuckets = types.BoolValue(config.RestrictPublicBuckets)
+	state.Id = types.StringValue(state.Bucket.ValueString())
+	resp.Diagnostics.Append(resp.State.Set(ctx, &state)...)
+}
+
+// Update updates the resource and sets the updated Terraform state on success.
+func (r *bucketPublicAccessBlockRessource) Update(ctx context.Context, req resource.UpdateRequest, resp *resource.UpdateResponse) {
+	var plan bucketPublicAccessBlockModel
+	resp.Diagnostics.Append(req.Plan.Get(ctx, &plan)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	config := &rustfs.PublicAccessBlockConfiguration{
+		BlockPublicAcls:       plan.BlockPublicAcls.ValueBool(),
+		IgnorePublicAcls:      plan.IgnorePublicAcls.ValueBool(),
+		BlockPublicPolicy:     plan.BlockPublicPolicy.ValueBool(),
+		RestrictPublicBuckets: plan.RestrictPublicBuckets.ValueBool(),
+	}
+
+	err := r.client.RustClient.SetBucketPublicAccessBlock(plan.Bucket.ValueString(), config)
+	if err != nil {
+		resp.Diagnostics.AddError(
+			"Error updating bucket public access block",
+			"Could not set public access block: "+err.Error(),
+		)
+		return
+	}
+
+	plan.Id = types.StringValue(plan.Bucket.ValueString())
+	resp.Diagnostics.Append(resp.State.Set(ctx, &plan)...)
+}
+
+// Delete deletes the resource and removes the Terraform state on success.
+func (r *bucketPublicAccessBlockRessource) Delete(ctx context.Context, req resource.DeleteRequest, resp *resource.DeleteResponse) {
+	var data bucketPublicAccessBlockModel
+	resp.Diagnostics.Append(req.State.Get(ctx, &data)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	err := r.client.RustClient.DeleteBucketPublicAccessBlock(data.Bucket.ValueString())
+	if err != nil {
+		if strings.Contains(err.Error(), "NoSuchPublicAccessBlockConfiguration") ||
+			strings.Contains(err.Error(), "NoSuchBucket") ||
+			strings.Contains(err.Error(), "404") {
+			// Already deleted
+			return
+		}
+		resp.Diagnostics.AddError(
+			"Error deleting bucket public access block",
+			"Could not delete public access block: "+err.Error(),
+		)
+		return
+	}
+}
+
+func (r *bucketPublicAccessBlockRessource) ImportState(ctx context.Context, req resource.ImportStateRequest, resp *resource.ImportStateResponse) {
+	resource.ImportStatePassthroughID(ctx, path.Root("bucket"), req, resp)
+}

--- a/provider/rustfs_bucket_public_access_block_ressource_test.go
+++ b/provider/rustfs_bucket_public_access_block_ressource_test.go
@@ -1,0 +1,93 @@
+package provider
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-framework/resource"
+	"github.com/hashicorp/terraform-plugin-testing/helper/acctest"
+	tfresource "github.com/hashicorp/terraform-plugin-testing/helper/resource"
+)
+
+func TestBucketPublicAccessBlockRessourceSchema(t *testing.T) {
+	r := NewBucketPublicAccessBlockRessource()
+	resp := &resource.SchemaResponse{}
+	r.Schema(context.TODO(), resource.SchemaRequest{}, resp)
+
+	if resp.Diagnostics.HasError() {
+		t.Fatalf("schema diagnostics: %v", resp.Diagnostics)
+	}
+
+	attrs := resp.Schema.GetAttributes()
+	for _, want := range []string{"bucket", "id", "block_public_acls", "ignore_public_acls", "block_public_policy", "restrict_public_buckets"} {
+		if _, ok := attrs[want]; !ok {
+			t.Errorf("missing attribute %q", want)
+		}
+	}
+}
+
+func TestBucketPublicAccessBlockRessourceMetadata(t *testing.T) {
+	r := NewBucketPublicAccessBlockRessource()
+	resp := &resource.MetadataResponse{}
+	r.Metadata(context.TODO(), resource.MetadataRequest{ProviderTypeName: "rustfs"}, resp)
+
+	if resp.TypeName != "rustfs_bucket_public_access_block" {
+		t.Errorf("expected rustfs_bucket_public_access_block, got %s", resp.TypeName)
+	}
+}
+
+func TestAccBucketPublicAccessBlock_basic(t *testing.T) {
+	name := fmt.Sprintf("tf-test-pab-%d", acctest.RandInt())
+	resourceName := "rustfs_bucket_public_access_block.test"
+
+	tfresource.ParallelTest(t, tfresource.TestCase{
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		CheckDestroy:             testAccCheckBucketDestroy,
+		Steps: []tfresource.TestStep{
+			{
+				Config: testAccBucketPublicAccessBlockConfig(name, true, false, true, false),
+				Check: tfresource.ComposeTestCheckFunc(
+					tfresource.TestCheckResourceAttr(resourceName, "bucket", name),
+					tfresource.TestCheckResourceAttr(resourceName, "id", name),
+					tfresource.TestCheckResourceAttr(resourceName, "block_public_acls", "true"),
+					tfresource.TestCheckResourceAttr(resourceName, "ignore_public_acls", "false"),
+					tfresource.TestCheckResourceAttr(resourceName, "block_public_policy", "true"),
+					tfresource.TestCheckResourceAttr(resourceName, "restrict_public_buckets", "false"),
+				),
+			},
+			{
+				Config: testAccBucketPublicAccessBlockConfig(name, false, true, true, true),
+				Check: tfresource.ComposeTestCheckFunc(
+					tfresource.TestCheckResourceAttr(resourceName, "block_public_acls", "false"),
+					tfresource.TestCheckResourceAttr(resourceName, "ignore_public_acls", "true"),
+					tfresource.TestCheckResourceAttr(resourceName, "block_public_policy", "true"),
+					tfresource.TestCheckResourceAttr(resourceName, "restrict_public_buckets", "true"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateId:     name,
+			},
+		},
+	})
+}
+
+func testAccBucketPublicAccessBlockConfig(bucket string, blockPublicAcls, ignorePublicAcls, blockPublicPolicy, restrictPublicBuckets bool) string {
+	return testAccProviderConfig() + fmt.Sprintf(`
+resource "rustfs_bucket" "test" {
+  name = "%s"
+}
+
+resource "rustfs_bucket_public_access_block" "test" {
+  bucket                = rustfs_bucket.test.name
+  block_public_acls     = %t
+  ignore_public_acls    = %t
+  block_public_policy   = %t
+  restrict_public_buckets = %t
+}
+`, bucket, blockPublicAcls, ignorePublicAcls, blockPublicPolicy, restrictPublicBuckets)
+}


### PR DESCRIPTION
**Issue:** https://github.com/weinmann-emt/terraform-provider-rustfs/issues/103

Add a `rustfs_bucket_public_access_block` resource for the block-public-access settings on a bucket.

Closes #103

## Changes
- `pkg/rustfs/public_access_block.go`: `PUT/GET/DELETE ?publicAccessBlock` via the custom S3 XML client (`DoDirectRequest`); namespace-tolerant parser (RustFS returns un-namespaced XML while accepting namespaced PUT).
- `provider/rustfs_bucket_public_access_block_ressource.go`, registered in `Resources()`.
- Unit (httptest) + acceptance tests; docs + example.

## Testing
- `go build`, `go vet`, gofmt clean; golangci-lint no new findings.
- 5/5 httptest unit tests + schema tests + acceptance test pass against a live RustFS.
