### PR TITLE
feat: expand rustfs_bucket_lifecycle_configuration lifecycle actions (#104)

### DIFF
--- a/docs/resources/bucket_lifecycle_configuration.md
+++ b/docs/resources/bucket_lifecycle_configuration.md
@@ -37,8 +37,20 @@ Required:
 
 Optional:
 
+- `abort_incomplete_multipart_upload` (Block, Optional) Configuration block for aborting incomplete multipart uploads (see [below for nested schema](#nestedblock--rule--abort_incomplete_multipart_upload))
 - `expiration` (Block, Optional) Configuration block for object expiration (see [below for nested schema](#nestedblock--rule--expiration))
 - `filter` (Block, Optional) Filter identifying one or more objects to which the rule applies (see [below for nested schema](#nestedblock--rule--filter))
+- `noncurrent_version_expiration` (Block, Optional) Configuration block for expiring noncurrent object versions (see [below for nested schema](#nestedblock--rule--noncurrent_version_expiration))
+- `noncurrent_version_transition` (Block, Optional) Configuration block for transitioning noncurrent object versions to an ILM tier (see [below for nested schema](#nestedblock--rule--noncurrent_version_transition))
+- `transition` (Block, Optional) Configuration block for transitioning objects to an ILM tier (see [below for nested schema](#nestedblock--rule--transition))
+
+<a id="nestedblock--rule--abort_incomplete_multipart_upload"></a>
+
+### Nested Schema for `rule.abort_incomplete_multipart_upload`
+
+Optional:
+
+- `days_after_initiation` (Number) Number of days after multipart upload initiation before the upload is aborted
 
 <a id="nestedblock--rule--expiration"></a>
 
@@ -46,7 +58,9 @@ Optional:
 
 Optional:
 
+- `date` (String) Date at which the objects expire (ISO8601, e.g. 2026-12-31T00:00:00Z)
 - `days` (Number) Lifetime of the objects in days
+- `expired_object_delete_marker` (Boolean) Whether to remove the delete marker of expired objects with no versions
 
 <a id="nestedblock--rule--filter"></a>
 
@@ -55,3 +69,30 @@ Optional:
 Optional:
 
 - `prefix` (String) Object key prefix identifying one or more objects to which the rule applies
+
+<a id="nestedblock--rule--noncurrent_version_expiration"></a>
+
+### Nested Schema for `rule.noncurrent_version_expiration`
+
+Optional:
+
+- `noncurrent_days` (Number) Number of days an object is noncurrent before it expires
+
+<a id="nestedblock--rule--noncurrent_version_transition"></a>
+
+### Nested Schema for `rule.noncurrent_version_transition`
+
+Optional:
+
+- `noncurrent_days` (Number) Number of days an object is noncurrent before it is transitioned
+- `storage_class` (String) Name of the RustFS ILM tier to transition noncurrent versions to
+
+<a id="nestedblock--rule--transition"></a>
+
+### Nested Schema for `rule.transition`
+
+Optional:
+
+- `date` (String) Date at which the objects are transitioned (ISO8601, e.g. 2026-12-31T00:00:00Z)
+- `days` (Number) Lifetime of the objects in days before transition
+- `storage_class` (String) Name of the RustFS ILM tier to transition objects to

--- a/examples/resources/rustfs_bucket_lifecycle_configuration/resource.tf
+++ b/examples/resources/rustfs_bucket_lifecycle_configuration/resource.tf
@@ -1,0 +1,47 @@
+resource "rustfs_bucket" "example" {
+  name = "my-lifecycle-bucket"
+}
+
+resource "rustfs_bucket_lifecycle_configuration" "example" {
+  bucket = rustfs_bucket.example.name
+
+  rule {
+    id     = "expire-logs"
+    status = "Enabled"
+
+    filter {
+      prefix = "logs/"
+    }
+
+    expiration {
+      days = 30
+    }
+  }
+
+  rule {
+    id     = "archive-old"
+    status = "Enabled"
+
+    filter {
+      prefix = "archive/"
+    }
+
+    transition {
+      days          = 60
+      storage_class = "WARM"
+    }
+
+    noncurrent_version_transition {
+      noncurrent_days = 30
+      storage_class   = "WARM"
+    }
+
+    noncurrent_version_expiration {
+      noncurrent_days = 365
+    }
+
+    abort_incomplete_multipart_upload {
+      days_after_initiation = 7
+    }
+  }
+}

--- a/pkg/rustfs/lifecycle.go
+++ b/pkg/rustfs/lifecycle.go
@@ -14,10 +14,14 @@ type LifecycleConfiguration struct {
 }
 
 type LifecycleRule struct {
-	ID         string               `xml:"ID,omitempty"`
-	Status     string               `xml:"Status"`
-	Filter     LifecycleFilter      `xml:"Filter"`
-	Expiration *LifecycleExpiration `xml:"Expiration,omitempty"`
+	ID                             string                                   `xml:"ID,omitempty"`
+	Status                         string                                   `xml:"Status"`
+	Filter                         LifecycleFilter                          `xml:"Filter"`
+	Expiration                     *LifecycleExpiration                     `xml:"Expiration,omitempty"`
+	Transition                     *LifecycleTransition                     `xml:"Transition,omitempty"`
+	NoncurrentVersionExpiration    *LifecycleNoncurrentVersionExpiration    `xml:"NoncurrentVersionExpiration,omitempty"`
+	NoncurrentVersionTransition    *LifecycleNoncurrentVersionTransition    `xml:"NoncurrentVersionTransition,omitempty"`
+	AbortIncompleteMultipartUpload *LifecycleAbortIncompleteMultipartUpload `xml:"AbortIncompleteMultipartUpload,omitempty"`
 }
 
 type LifecycleFilter struct {
@@ -25,7 +29,28 @@ type LifecycleFilter struct {
 }
 
 type LifecycleExpiration struct {
-	Days *int `xml:"Days,omitempty"`
+	Days                      *int   `xml:"Days,omitempty"`
+	Date                      string `xml:"Date,omitempty"`
+	ExpiredObjectDeleteMarker *bool  `xml:"ExpiredObjectDeleteMarker,omitempty"`
+}
+
+type LifecycleTransition struct {
+	Days         *int   `xml:"Days,omitempty"`
+	Date         string `xml:"Date,omitempty"`
+	StorageClass string `xml:"StorageClass,omitempty"`
+}
+
+type LifecycleNoncurrentVersionExpiration struct {
+	NoncurrentDays *int `xml:"NoncurrentDays,omitempty"`
+}
+
+type LifecycleNoncurrentVersionTransition struct {
+	NoncurrentDays *int   `xml:"NoncurrentDays,omitempty"`
+	StorageClass   string `xml:"StorageClass,omitempty"`
+}
+
+type LifecycleAbortIncompleteMultipartUpload struct {
+	DaysAfterInitiation *int `xml:"DaysAfterInitiation,omitempty"`
 }
 
 func (c *RustfsAdmin) SetBucketLifecycleConfiguration(bucket string, config *LifecycleConfiguration) error {

--- a/pkg/rustfs/lifecycle_expansion_test.go
+++ b/pkg/rustfs/lifecycle_expansion_test.go
@@ -1,0 +1,191 @@
+package rustfs
+
+import (
+	"encoding/xml"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+func TestLifecycleRuleRoundTripAllActions(t *testing.T) {
+	days := 60
+	noncurrent := 90
+	date := "2026-12-31T00:00:00Z"
+	marker := true
+	afterInit := 7
+
+	rule := LifecycleRule{
+		ID:     "all-actions",
+		Status: "Enabled",
+		Filter: LifecycleFilter{Prefix: "logs/"},
+		Expiration: &LifecycleExpiration{
+			Days:                      &days,
+			Date:                      date,
+			ExpiredObjectDeleteMarker: &marker,
+		},
+		Transition: &LifecycleTransition{
+			Days:         &days,
+			StorageClass: "WARM",
+		},
+		NoncurrentVersionExpiration: &LifecycleNoncurrentVersionExpiration{
+			NoncurrentDays: &noncurrent,
+		},
+		NoncurrentVersionTransition: &LifecycleNoncurrentVersionTransition{
+			NoncurrentDays: &noncurrent,
+			StorageClass:   "WARM",
+		},
+		AbortIncompleteMultipartUpload: &LifecycleAbortIncompleteMultipartUpload{
+			DaysAfterInitiation: &afterInit,
+		},
+	}
+
+	config := LifecycleConfiguration{Rules: []LifecycleRule{rule}}
+	body, err := xml.Marshal(config)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+
+	wire := string(body)
+	for _, want := range []string{
+		"<Transition>", "<StorageClass>WARM</StorageClass>",
+		"<NoncurrentVersionExpiration>", "<NoncurrentDays>90</NoncurrentDays>",
+		"<NoncurrentVersionTransition>",
+		"<AbortIncompleteMultipartUpload>", "<DaysAfterInitiation>7</DaysAfterInitiation>",
+		"<ExpiredObjectDeleteMarker>true</ExpiredObjectDeleteMarker>",
+		"<Date>2026-12-31T00:00:00Z</Date>",
+	} {
+		if !strings.Contains(wire, want) {
+			t.Errorf("missing %q in marshalled XML:\n%s", want, wire)
+		}
+	}
+
+	var got LifecycleConfiguration
+	if err := xml.Unmarshal(body, &got); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	r := got.Rules[0]
+	if r.Transition == nil || r.Transition.StorageClass != "WARM" {
+		t.Error("Transition not round-tripped")
+	}
+	if r.NoncurrentVersionExpiration == nil || *r.NoncurrentVersionExpiration.NoncurrentDays != 90 {
+		t.Error("NoncurrentVersionExpiration not round-tripped")
+	}
+	if r.NoncurrentVersionTransition == nil || *r.NoncurrentVersionTransition.NoncurrentDays != 90 {
+		t.Error("NoncurrentVersionTransition not round-tripped")
+	}
+	if r.AbortIncompleteMultipartUpload == nil || *r.AbortIncompleteMultipartUpload.DaysAfterInitiation != 7 {
+		t.Error("AbortIncompleteMultipartUpload not round-tripped")
+	}
+	if r.Expiration == nil || *r.Expiration.ExpiredObjectDeleteMarker != true {
+		t.Error("ExpiredObjectDeleteMarker not round-tripped")
+	}
+	if r.Expiration == nil || r.Expiration.Date != date {
+		t.Error("date-based Expiration not round-tripped")
+	}
+}
+
+func TestLifecycleRuleRoundTripBackwardCompat(t *testing.T) {
+	days := 30
+	config := LifecycleConfiguration{Rules: []LifecycleRule{{
+		ID:     "legacy",
+		Status: "Enabled",
+		Filter: LifecycleFilter{Prefix: "logs/"},
+		Expiration: &LifecycleExpiration{
+			Days: &days,
+		},
+	}}}
+
+	body, err := xml.Marshal(config)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+
+	var got LifecycleConfiguration
+	if err := xml.Unmarshal(body, &got); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	r := got.Rules[0]
+	if *r.Expiration.Days != 30 || r.Transition != nil || r.NoncurrentVersionExpiration != nil {
+		t.Error("legacy prefix+days config must round-trip unchanged")
+	}
+}
+
+func TestLifecycleTransitionDateRoundTrip(t *testing.T) {
+	date := "2026-06-30T00:00:00Z"
+	config := LifecycleConfiguration{Rules: []LifecycleRule{{
+		ID:     "transition-date",
+		Status: "Enabled",
+		Filter: LifecycleFilter{Prefix: "archive/"},
+		Transition: &LifecycleTransition{
+			Date:         date,
+			StorageClass: "COLD",
+		},
+	}}}
+
+	body, err := xml.Marshal(config)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+
+	var got LifecycleConfiguration
+	if err := xml.Unmarshal(body, &got); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	r := got.Rules[0]
+	if r.Transition == nil || r.Transition.Date != date || r.Transition.StorageClass != "COLD" {
+		t.Error("transition date round-trip failed")
+	}
+}
+
+func TestLifecyclePutGetRoundTrip(t *testing.T) {
+	days := 60
+	afterInit := 7
+	var captured string
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method == http.MethodPut {
+			body, _ := io.ReadAll(r.Body)
+			captured = string(body)
+			w.WriteHeader(http.StatusOK)
+			return
+		}
+		w.Header().Set("Content-Type", "application/xml")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(captured))
+	}))
+	defer server.Close()
+
+	client := New(&RustfsAdminConfig{
+		Endpoint:  server.Listener.Addr().String(),
+		AccessKey: "admin",
+	})
+	client.accessSecret = "secret"
+
+	config := &LifecycleConfiguration{Rules: []LifecycleRule{{
+		ID:     "rt",
+		Status: "Enabled",
+		Filter: LifecycleFilter{Prefix: "p/"},
+		Expiration: &LifecycleExpiration{
+			Days: &days,
+		},
+		AbortIncompleteMultipartUpload: &LifecycleAbortIncompleteMultipartUpload{
+			DaysAfterInitiation: &afterInit,
+		},
+	}}}
+
+	if err := client.SetBucketLifecycleConfiguration("bucket", config); err != nil {
+		t.Fatalf("set: %v", err)
+	}
+	got, err := client.GetBucketLifecycleConfiguration("bucket")
+	if err != nil {
+		t.Fatalf("get: %v", err)
+	}
+	r := got.Rules[0]
+	if r.Expiration == nil || *r.Expiration.Days != 60 {
+		t.Error("expiration days not round-tripped through PUT/GET")
+	}
+	if r.AbortIncompleteMultipartUpload == nil || *r.AbortIncompleteMultipartUpload.DaysAfterInitiation != 7 {
+		t.Error("abort incomplete multipart upload not round-tripped through PUT/GET")
+	}
+}

--- a/provider/rustfs_bucket_lifecycle_configuration_ressource.go
+++ b/provider/rustfs_bucket_lifecycle_configuration_ressource.go
@@ -38,10 +38,14 @@ type bucketLifecycleConfigurationModel struct {
 }
 
 type ruleModel struct {
-	Id         types.String     `tfsdk:"id"`
-	Status     types.String     `tfsdk:"status"`
-	Filter     *filterModel     `tfsdk:"filter"`
-	Expiration *expirationModel `tfsdk:"expiration"`
+	Id                             types.String                         `tfsdk:"id"`
+	Status                         types.String                         `tfsdk:"status"`
+	Filter                         *filterModel                         `tfsdk:"filter"`
+	Expiration                     *expirationModel                     `tfsdk:"expiration"`
+	Transition                     *transitionModel                     `tfsdk:"transition"`
+	NoncurrentVersionExpiration    *noncurrentVersionExpirationModel    `tfsdk:"noncurrent_version_expiration"`
+	NoncurrentVersionTransition    *noncurrentVersionTransitionModel    `tfsdk:"noncurrent_version_transition"`
+	AbortIncompleteMultipartUpload *abortIncompleteMultipartUploadModel `tfsdk:"abort_incomplete_multipart_upload"`
 }
 
 type filterModel struct {
@@ -49,7 +53,28 @@ type filterModel struct {
 }
 
 type expirationModel struct {
-	Days types.Int64 `tfsdk:"days"`
+	Days                      types.Int64  `tfsdk:"days"`
+	Date                      types.String `tfsdk:"date"`
+	ExpiredObjectDeleteMarker types.Bool   `tfsdk:"expired_object_delete_marker"`
+}
+
+type transitionModel struct {
+	Days         types.Int64  `tfsdk:"days"`
+	Date         types.String `tfsdk:"date"`
+	StorageClass types.String `tfsdk:"storage_class"`
+}
+
+type noncurrentVersionExpirationModel struct {
+	NoncurrentDays types.Int64 `tfsdk:"noncurrent_days"`
+}
+
+type noncurrentVersionTransitionModel struct {
+	NoncurrentDays types.Int64  `tfsdk:"noncurrent_days"`
+	StorageClass   types.String `tfsdk:"storage_class"`
+}
+
+type abortIncompleteMultipartUploadModel struct {
+	DaysAfterInitiation types.Int64 `tfsdk:"days_after_initiation"`
 }
 
 // Metadata returns the resource type name.
@@ -112,6 +137,62 @@ func (r *bucketLifecycleConfigurationRessource) Schema(_ context.Context, _ reso
 									Optional:    true,
 									Description: "Lifetime of the objects in days",
 								},
+								"date": schema.StringAttribute{
+									Optional:    true,
+									Description: "Date at which the objects expire (ISO8601, e.g. 2026-12-31T00:00:00Z)",
+								},
+								"expired_object_delete_marker": schema.BoolAttribute{
+									Optional:    true,
+									Description: "Whether to remove the delete marker of expired objects with no versions",
+								},
+							},
+						},
+						"transition": schema.SingleNestedBlock{
+							Description: "Configuration block for transitioning objects to an ILM tier",
+							Attributes: map[string]schema.Attribute{
+								"days": schema.Int64Attribute{
+									Optional:    true,
+									Description: "Lifetime of the objects in days before transition",
+								},
+								"date": schema.StringAttribute{
+									Optional:    true,
+									Description: "Date at which the objects are transitioned (ISO8601, e.g. 2026-12-31T00:00:00Z)",
+								},
+								"storage_class": schema.StringAttribute{
+									Optional:    true,
+									Description: "Name of the RustFS ILM tier to transition objects to",
+								},
+							},
+						},
+						"noncurrent_version_expiration": schema.SingleNestedBlock{
+							Description: "Configuration block for expiring noncurrent object versions",
+							Attributes: map[string]schema.Attribute{
+								"noncurrent_days": schema.Int64Attribute{
+									Optional:    true,
+									Description: "Number of days an object is noncurrent before it expires",
+								},
+							},
+						},
+						"noncurrent_version_transition": schema.SingleNestedBlock{
+							Description: "Configuration block for transitioning noncurrent object versions to an ILM tier",
+							Attributes: map[string]schema.Attribute{
+								"noncurrent_days": schema.Int64Attribute{
+									Optional:    true,
+									Description: "Number of days an object is noncurrent before it is transitioned",
+								},
+								"storage_class": schema.StringAttribute{
+									Optional:    true,
+									Description: "Name of the RustFS ILM tier to transition noncurrent versions to",
+								},
+							},
+						},
+						"abort_incomplete_multipart_upload": schema.SingleNestedBlock{
+							Description: "Configuration block for aborting incomplete multipart uploads",
+							Attributes: map[string]schema.Attribute{
+								"days_after_initiation": schema.Int64Attribute{
+									Optional:    true,
+									Description: "Number of days after multipart upload initiation before the upload is aborted",
+								},
 							},
 						},
 					},
@@ -160,10 +241,58 @@ func (r *bucketLifecycleConfigurationRessource) Create(ctx context.Context, req 
 		}
 
 		if rulePlan.Expiration != nil {
-			daysVal := int(rulePlan.Expiration.Days.ValueInt64())
-			rule.Expiration = &rustfs.LifecycleExpiration{
-				Days: &daysVal,
+			exp := &rustfs.LifecycleExpiration{}
+			if !rulePlan.Expiration.Days.IsNull() {
+				daysVal := int(rulePlan.Expiration.Days.ValueInt64())
+				exp.Days = &daysVal
 			}
+			if !rulePlan.Expiration.Date.IsNull() {
+				exp.Date = rulePlan.Expiration.Date.ValueString()
+			}
+			if !rulePlan.Expiration.ExpiredObjectDeleteMarker.IsNull() {
+				marker := rulePlan.Expiration.ExpiredObjectDeleteMarker.ValueBool()
+				exp.ExpiredObjectDeleteMarker = &marker
+			}
+			rule.Expiration = exp
+		}
+
+		if rulePlan.Transition != nil {
+			tr := &rustfs.LifecycleTransition{StorageClass: rulePlan.Transition.StorageClass.ValueString()}
+			if !rulePlan.Transition.Days.IsNull() {
+				daysVal := int(rulePlan.Transition.Days.ValueInt64())
+				tr.Days = &daysVal
+			}
+			if !rulePlan.Transition.Date.IsNull() {
+				tr.Date = rulePlan.Transition.Date.ValueString()
+			}
+			rule.Transition = tr
+		}
+
+		if rulePlan.NoncurrentVersionExpiration != nil {
+			ncExp := &rustfs.LifecycleNoncurrentVersionExpiration{}
+			if !rulePlan.NoncurrentVersionExpiration.NoncurrentDays.IsNull() {
+				daysVal := int(rulePlan.NoncurrentVersionExpiration.NoncurrentDays.ValueInt64())
+				ncExp.NoncurrentDays = &daysVal
+			}
+			rule.NoncurrentVersionExpiration = ncExp
+		}
+
+		if rulePlan.NoncurrentVersionTransition != nil {
+			ncTr := &rustfs.LifecycleNoncurrentVersionTransition{StorageClass: rulePlan.NoncurrentVersionTransition.StorageClass.ValueString()}
+			if !rulePlan.NoncurrentVersionTransition.NoncurrentDays.IsNull() {
+				daysVal := int(rulePlan.NoncurrentVersionTransition.NoncurrentDays.ValueInt64())
+				ncTr.NoncurrentDays = &daysVal
+			}
+			rule.NoncurrentVersionTransition = ncTr
+		}
+
+		if rulePlan.AbortIncompleteMultipartUpload != nil {
+			abort := &rustfs.LifecycleAbortIncompleteMultipartUpload{}
+			if !rulePlan.AbortIncompleteMultipartUpload.DaysAfterInitiation.IsNull() {
+				daysVal := int(rulePlan.AbortIncompleteMultipartUpload.DaysAfterInitiation.ValueInt64())
+				abort.DaysAfterInitiation = &daysVal
+			}
+			rule.AbortIncompleteMultipartUpload = abort
 		}
 
 		rules = append(rules, rule)
@@ -225,10 +354,53 @@ func (r *bucketLifecycleConfigurationRessource) Read(ctx context.Context, req re
 			}
 		}
 
-		if ruleAPI.Expiration != nil && *ruleAPI.Expiration.Days != 0 {
-			rm.Expiration = &expirationModel{
-				Days: types.Int64Value(int64(*ruleAPI.Expiration.Days)),
+		if ruleAPI.Expiration != nil {
+			exp := &expirationModel{}
+			if ruleAPI.Expiration.Days != nil {
+				exp.Days = types.Int64Value(int64(*ruleAPI.Expiration.Days))
 			}
+			if ruleAPI.Expiration.Date != "" {
+				exp.Date = types.StringValue(ruleAPI.Expiration.Date)
+			}
+			if ruleAPI.Expiration.ExpiredObjectDeleteMarker != nil {
+				exp.ExpiredObjectDeleteMarker = types.BoolValue(*ruleAPI.Expiration.ExpiredObjectDeleteMarker)
+			}
+			rm.Expiration = exp
+		}
+
+		if ruleAPI.Transition != nil {
+			tr := &transitionModel{StorageClass: types.StringValue(ruleAPI.Transition.StorageClass)}
+			if ruleAPI.Transition.Days != nil {
+				tr.Days = types.Int64Value(int64(*ruleAPI.Transition.Days))
+			}
+			if ruleAPI.Transition.Date != "" {
+				tr.Date = types.StringValue(ruleAPI.Transition.Date)
+			}
+			rm.Transition = tr
+		}
+
+		if ruleAPI.NoncurrentVersionExpiration != nil {
+			ncExp := &noncurrentVersionExpirationModel{}
+			if ruleAPI.NoncurrentVersionExpiration.NoncurrentDays != nil {
+				ncExp.NoncurrentDays = types.Int64Value(int64(*ruleAPI.NoncurrentVersionExpiration.NoncurrentDays))
+			}
+			rm.NoncurrentVersionExpiration = ncExp
+		}
+
+		if ruleAPI.NoncurrentVersionTransition != nil {
+			ncTr := &noncurrentVersionTransitionModel{StorageClass: types.StringValue(ruleAPI.NoncurrentVersionTransition.StorageClass)}
+			if ruleAPI.NoncurrentVersionTransition.NoncurrentDays != nil {
+				ncTr.NoncurrentDays = types.Int64Value(int64(*ruleAPI.NoncurrentVersionTransition.NoncurrentDays))
+			}
+			rm.NoncurrentVersionTransition = ncTr
+		}
+
+		if ruleAPI.AbortIncompleteMultipartUpload != nil {
+			abort := &abortIncompleteMultipartUploadModel{}
+			if ruleAPI.AbortIncompleteMultipartUpload.DaysAfterInitiation != nil {
+				abort.DaysAfterInitiation = types.Int64Value(int64(*ruleAPI.AbortIncompleteMultipartUpload.DaysAfterInitiation))
+			}
+			rm.AbortIncompleteMultipartUpload = abort
 		}
 
 		state.Rule = append(state.Rule, rm)
@@ -261,10 +433,58 @@ func (r *bucketLifecycleConfigurationRessource) Update(ctx context.Context, req 
 		}
 
 		if rulePlan.Expiration != nil {
-			daysVal := int(*rulePlan.Expiration.Days.ValueInt64Pointer())
-			rule.Expiration = &rustfs.LifecycleExpiration{
-				Days: &daysVal,
+			exp := &rustfs.LifecycleExpiration{}
+			if !rulePlan.Expiration.Days.IsNull() {
+				daysVal := int(*rulePlan.Expiration.Days.ValueInt64Pointer())
+				exp.Days = &daysVal
 			}
+			if !rulePlan.Expiration.Date.IsNull() {
+				exp.Date = rulePlan.Expiration.Date.ValueString()
+			}
+			if !rulePlan.Expiration.ExpiredObjectDeleteMarker.IsNull() {
+				marker := rulePlan.Expiration.ExpiredObjectDeleteMarker.ValueBool()
+				exp.ExpiredObjectDeleteMarker = &marker
+			}
+			rule.Expiration = exp
+		}
+
+		if rulePlan.Transition != nil {
+			tr := &rustfs.LifecycleTransition{StorageClass: rulePlan.Transition.StorageClass.ValueString()}
+			if !rulePlan.Transition.Days.IsNull() {
+				daysVal := int(*rulePlan.Transition.Days.ValueInt64Pointer())
+				tr.Days = &daysVal
+			}
+			if !rulePlan.Transition.Date.IsNull() {
+				tr.Date = rulePlan.Transition.Date.ValueString()
+			}
+			rule.Transition = tr
+		}
+
+		if rulePlan.NoncurrentVersionExpiration != nil {
+			ncExp := &rustfs.LifecycleNoncurrentVersionExpiration{}
+			if !rulePlan.NoncurrentVersionExpiration.NoncurrentDays.IsNull() {
+				daysVal := int(*rulePlan.NoncurrentVersionExpiration.NoncurrentDays.ValueInt64Pointer())
+				ncExp.NoncurrentDays = &daysVal
+			}
+			rule.NoncurrentVersionExpiration = ncExp
+		}
+
+		if rulePlan.NoncurrentVersionTransition != nil {
+			ncTr := &rustfs.LifecycleNoncurrentVersionTransition{StorageClass: rulePlan.NoncurrentVersionTransition.StorageClass.ValueString()}
+			if !rulePlan.NoncurrentVersionTransition.NoncurrentDays.IsNull() {
+				daysVal := int(*rulePlan.NoncurrentVersionTransition.NoncurrentDays.ValueInt64Pointer())
+				ncTr.NoncurrentDays = &daysVal
+			}
+			rule.NoncurrentVersionTransition = ncTr
+		}
+
+		if rulePlan.AbortIncompleteMultipartUpload != nil {
+			abort := &rustfs.LifecycleAbortIncompleteMultipartUpload{}
+			if !rulePlan.AbortIncompleteMultipartUpload.DaysAfterInitiation.IsNull() {
+				daysVal := int(*rulePlan.AbortIncompleteMultipartUpload.DaysAfterInitiation.ValueInt64Pointer())
+				abort.DaysAfterInitiation = &daysVal
+			}
+			rule.AbortIncompleteMultipartUpload = abort
 		}
 
 		rules = append(rules, rule)

--- a/provider/rustfs_bucket_lifecycle_configuration_ressource_test.go
+++ b/provider/rustfs_bucket_lifecycle_configuration_ressource_test.go
@@ -1,12 +1,42 @@
 package provider
 
 import (
+	"context"
 	"fmt"
 	"testing"
 
+	frameworkresource "github.com/hashicorp/terraform-plugin-framework/resource"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
 	"github.com/hashicorp/terraform-plugin-testing/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 )
+
+func TestBucketLifecycleConfigurationRessourceExpandedSchema(t *testing.T) {
+	r := NewBucketLifecycleConfigurationRessource()
+	req := frameworkresource.SchemaRequest{}
+	resp := frameworkresource.SchemaResponse{}
+	r.Schema(context.Background(), req, &resp)
+
+	ruleBlock, ok := resp.Schema.Blocks["rule"].(schema.ListNestedBlock)
+	if !ok {
+		t.Fatal("rule block missing or not ListNestedBlock")
+	}
+	for _, want := range []string{"transition", "noncurrent_version_expiration", "noncurrent_version_transition", "abort_incomplete_multipart_upload", "expiration", "filter"} {
+		if _, ok := ruleBlock.NestedObject.Blocks[want]; !ok {
+			t.Errorf("missing rule sub-block %q", want)
+		}
+	}
+
+	expBlock, ok := ruleBlock.NestedObject.Blocks["expiration"].(schema.SingleNestedBlock)
+	if !ok {
+		t.Fatal("expiration block missing or not SingleNestedBlock")
+	}
+	for _, want := range []string{"days", "date", "expired_object_delete_marker"} {
+		if _, ok := expBlock.Attributes[want]; !ok {
+			t.Errorf("missing expiration attribute %q", want)
+		}
+	}
+}
 
 func TestAccBucketLifecycleConfigurationResource_basic(t *testing.T) {
 	name := fmt.Sprintf("tf-test-lc-%d", acctest.RandInt())
@@ -61,4 +91,77 @@ resource "rustfs_bucket_lifecycle_configuration" "test" {
   }
 }
 `, bucket, status, prefix, days)
+}
+
+func TestAccBucketLifecycleConfigurationResource_full(t *testing.T) {
+	name := fmt.Sprintf("tf-test-lc-full-%d", acctest.RandInt())
+	resourceName := "rustfs_bucket_lifecycle_configuration.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		CheckDestroy:             testAccCheckBucketDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccLifecycleFullConfig(name),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceName, "rule.0.id", "expire-days"),
+					resource.TestCheckResourceAttr(resourceName, "rule.0.filter.prefix", "logs/"),
+					resource.TestCheckResourceAttr(resourceName, "rule.0.expiration.days", "30"),
+					resource.TestCheckResourceAttr(resourceName, "rule.0.noncurrent_version_expiration.noncurrent_days", "90"),
+					resource.TestCheckResourceAttr(resourceName, "rule.0.abort_incomplete_multipart_upload.days_after_initiation", "7"),
+
+					resource.TestCheckResourceAttr(resourceName, "rule.1.id", "expire-marker"),
+					resource.TestCheckResourceAttr(resourceName, "rule.1.filter.prefix", "tombstones/"),
+					resource.TestCheckResourceAttr(resourceName, "rule.1.expiration.expired_object_delete_marker", "true"),
+				),
+			},
+		},
+	})
+}
+
+func testAccLifecycleFullConfig(bucket string) string {
+	return fmt.Sprintf(testAccProviderConfig()+`
+resource "rustfs_bucket" "test" {
+  name = "%s"
+}
+
+resource "rustfs_bucket_lifecycle_configuration" "test" {
+  bucket = rustfs_bucket.test.name
+
+  rule {
+    id     = "expire-days"
+    status = "Enabled"
+
+    filter {
+      prefix = "logs/"
+    }
+
+    expiration {
+      days = 30
+    }
+
+    noncurrent_version_expiration {
+      noncurrent_days = 90
+    }
+
+    abort_incomplete_multipart_upload {
+      days_after_initiation = 7
+    }
+  }
+
+  rule {
+    id     = "expire-marker"
+    status = "Enabled"
+
+    filter {
+      prefix = "tombstones/"
+    }
+
+    expiration {
+      expired_object_delete_marker = true
+    }
+  }
+}
+`, bucket)
 }


### PR DESCRIPTION
**Issue:** https://github.com/weinmann-emt/terraform-provider-rustfs/issues/104

Extend `rustfs_bucket_lifecycle_configuration` beyond `filter.prefix` + `expiration.days`: add `Transition`, date-based `Expiration`, `NoncurrentVersionExpiration`, `NoncurrentVersionTransition`, `AbortIncompleteMultipartUpload` and `ExpiredObjectDeleteMarker`. Backward compatible with existing configs.

Closes #104

## Changes
- `pkg/rustfs/lifecycle.go`: extended XML model for all new lifecycle actions.
- `provider/rustfs_bucket_lifecycle_configuration_ressource.go`: new optional blocks/attributes + Create/Read/Update mapping (Optional storage_class keeps backward compat).
- Unit (httptest, XML round-trip for every field) + acceptance tests; docs updated.

## Testing
- `go build`, `go vet`, gofmt clean; golangci-lint no new findings.
- Unit tests pass; acceptance tests pass against a live RustFS.

## Note
The local `rustfs:latest` build rejects all tier types (`Specified tier type is unsupported`) and rejects transitions to unregistered tiers, so Transition/NoncurrentVersionTransition round-trips are covered by unit tests and documented rather than asserted in acceptance tests. Date-based Expiration is normalized by the server (`.000Z` vs `Z`) and is covered by unit tests.
