### PR TITLE
feat: add rustfs_ilm_tier_stats data source (#108)

### DIFF
--- a/docs/data-sources/ilm_tier_stats.md
+++ b/docs/data-sources/ilm_tier_stats.md
@@ -1,0 +1,36 @@
+---
+page_title: "rustfs_ilm_tier_stats Data Source - rustfs"
+description: |-
+  Expose per-tier ILM storage statistics
+---
+
+# rustfs_ilm_tier_stats (Data Source)
+
+Exposes per-tier ILM storage statistics (object counts and sizes) from RustFS.
+
+## Example Usage
+
+```terraform
+data "rustfs_ilm_tier_stats" "all" {}
+
+output "tiers" {
+  value = data.rustfs_ilm_tier_stats.all.tiers
+}
+```
+
+## Schema
+
+### Read-Only
+
+- `id` (String) Data source identifier.
+- `tiers` (Attributes List) Per-tier statistics. See [below for nested schema](#nestedatt--tiers).
+
+<a id="nestedatt--tiers"></a>
+### Nested Schema for `tiers`
+
+Read-Only:
+
+- `name` (String) Tier name.
+- `num_objects` (Number) Number of objects on the tier.
+- `num_versions` (Number) Number of object versions on the tier.
+- `total_size` (Number) Total object size in bytes.

--- a/examples/data-sources/rustfs_ilm_tier_stats/data-source.tf
+++ b/examples/data-sources/rustfs_ilm_tier_stats/data-source.tf
@@ -1,0 +1,5 @@
+data "rustfs_ilm_tier_stats" "all" {}
+
+output "tiers" {
+  value = data.rustfs_ilm_tier_stats.all.tiers
+}

--- a/pkg/rustfs/tier.go
+++ b/pkg/rustfs/tier.go
@@ -51,3 +51,30 @@ func (c *RustfsAdmin) RemoveTier(name string) error {
 	defer resp.Body.Close()
 	return nil
 }
+
+// TierStat holds per-tier usage statistics as reported by the tier-stats
+// endpoint.
+type TierStat struct {
+	TotalSize   int64 `json:"total_size"`
+	NumVersions int64 `json:"num_versions"`
+	NumObjects  int64 `json:"num_objects"`
+}
+
+// TierStats returns per-tier usage statistics keyed by tier name. When no
+// tiers are configured the server returns an empty map.
+func (c *RustfsAdmin) TierStats() (map[string]TierStat, error) {
+	reqData := RequestData{
+		Method:  "GET",
+		RelPath: "tier-stats",
+	}
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	resp, err := c.doRequest(ctx, reqData)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+	var stats map[string]TierStat
+	err = json.NewDecoder(resp.Body).Decode(&stats)
+	return stats, err
+}

--- a/pkg/rustfs/tier_stats_test.go
+++ b/pkg/rustfs/tier_stats_test.go
@@ -1,0 +1,72 @@
+package rustfs
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+func TestTierStats(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodGet {
+			t.Errorf("expected GET, got %s", r.Method)
+		}
+		if !strings.Contains(r.URL.Path, "/rustfs/admin/v3/tier-stats") {
+			t.Errorf("unexpected path: %s", r.URL.Path)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"WARM":{"total_size":15,"num_versions":3,"num_objects":1},"ARCHIVE":{"total_size":9,"num_versions":1,"num_objects":1}}`))
+	}))
+	defer server.Close()
+
+	client := New(&RustfsAdminConfig{
+		Endpoint:  server.Listener.Addr().String(),
+		AccessKey: "admin",
+	})
+	client.accessSecret = "secret"
+
+	stats, err := client.TierStats()
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(stats) != 2 {
+		t.Fatalf("expected 2 tiers, got %d: %v", len(stats), stats)
+	}
+	warm, ok := stats["WARM"]
+	if !ok {
+		t.Fatalf("expected WARM tier, got %v", stats)
+	}
+	if warm.TotalSize != 15 || warm.NumVersions != 3 || warm.NumObjects != 1 {
+		t.Errorf("unexpected WARM stats: %+v", warm)
+	}
+	archive, ok := stats["ARCHIVE"]
+	if !ok {
+		t.Fatalf("expected ARCHIVE tier, got %v", stats)
+	}
+	if archive.TotalSize != 9 || archive.NumVersions != 1 || archive.NumObjects != 1 {
+		t.Errorf("unexpected ARCHIVE stats: %+v", archive)
+	}
+}
+
+func TestTierStatsEmpty(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{}`))
+	}))
+	defer server.Close()
+
+	client := New(&RustfsAdminConfig{
+		Endpoint:  server.Listener.Addr().String(),
+		AccessKey: "admin",
+	})
+	client.accessSecret = "secret"
+
+	stats, err := client.TierStats()
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(stats) != 0 {
+		t.Fatalf("expected no tiers, got %v", stats)
+	}
+}

--- a/provider/provider.go
+++ b/provider/provider.go
@@ -148,6 +148,7 @@ func (p *RustfsProvider) DataSources(ctx context.Context) []func() datasource.Da
 		NewUsersDataSource,
 		NewIAMPoliciesDataSource,
 		NewIAMPolicyDataSource,
+		NewIlmTierStatsDataSource,
 	}
 }
 

--- a/provider/rustfs_ilm_tier_stats_datasource.go
+++ b/provider/rustfs_ilm_tier_stats_datasource.go
@@ -1,0 +1,140 @@
+package provider
+
+import (
+	"context"
+	"fmt"
+	"sort"
+
+	"github.com/hashicorp/terraform-plugin-framework/attr"
+	"github.com/hashicorp/terraform-plugin-framework/datasource"
+	"github.com/hashicorp/terraform-plugin-framework/datasource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+)
+
+var _ datasource.DataSource = &IlmTierStatsDataSource{}
+
+type IlmTierStatsDataSource struct {
+	client *AllClient
+}
+
+type IlmTierStatsDataSourceModel struct {
+	ID    types.String `tfsdk:"id"`
+	Tiers types.List   `tfsdk:"tiers"`
+}
+
+type TierStatsModel struct {
+	Name        types.String `tfsdk:"name"`
+	NumObjects  types.Int64  `tfsdk:"num_objects"`
+	NumVersions types.Int64  `tfsdk:"num_versions"`
+	TotalSize   types.Int64  `tfsdk:"total_size"`
+}
+
+func NewIlmTierStatsDataSource() datasource.DataSource {
+	return &IlmTierStatsDataSource{}
+}
+
+func (d *IlmTierStatsDataSource) Metadata(_ context.Context, req datasource.MetadataRequest, resp *datasource.MetadataResponse) {
+	resp.TypeName = req.ProviderTypeName + "_ilm_tier_stats"
+}
+
+func (d *IlmTierStatsDataSource) Schema(_ context.Context, _ datasource.SchemaRequest, resp *datasource.SchemaResponse) {
+	resp.Schema = schema.Schema{
+		Description:         "Expose per-tier ILM storage statistics",
+		MarkdownDescription: "Exposes per-tier ILM storage statistics (object counts and sizes) from RustFS.",
+		Attributes: map[string]schema.Attribute{
+			"id": schema.StringAttribute{
+				Computed:    true,
+				Description: "Data source identifier.",
+			},
+			"tiers": schema.ListNestedAttribute{
+				Computed:    true,
+				Description: "Per-tier statistics.",
+				NestedObject: schema.NestedAttributeObject{
+					Attributes: map[string]schema.Attribute{
+						"name": schema.StringAttribute{
+							Computed:    true,
+							Description: "Tier name.",
+						},
+						"num_objects": schema.Int64Attribute{
+							Computed:    true,
+							Description: "Number of objects on the tier.",
+						},
+						"num_versions": schema.Int64Attribute{
+							Computed:    true,
+							Description: "Number of object versions on the tier.",
+						},
+						"total_size": schema.Int64Attribute{
+							Computed:    true,
+							Description: "Total object size in bytes.",
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+func (d *IlmTierStatsDataSource) Configure(_ context.Context, req datasource.ConfigureRequest, resp *datasource.ConfigureResponse) {
+	if req.ProviderData == nil {
+		return
+	}
+	client, ok := req.ProviderData.(*AllClient)
+	if !ok {
+		resp.Diagnostics.AddError(
+			"Unexpected Data Source Configure Type",
+			fmt.Sprintf("Expected *AllClient, got: %T. Please report this issue to the provider developers.", req.ProviderData),
+		)
+		return
+	}
+	d.client = client
+}
+
+func (d *IlmTierStatsDataSource) Read(ctx context.Context, req datasource.ReadRequest, resp *datasource.ReadResponse) {
+	var config IlmTierStatsDataSourceModel
+	resp.Diagnostics.Append(req.Config.Get(ctx, &config)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	stats, err := d.client.RustClient.TierStats()
+	if err != nil {
+		resp.Diagnostics.AddError(
+			"Error reading tier stats",
+			"Could not read tier stats: "+err.Error(),
+		)
+		return
+	}
+
+	names := make([]string, 0, len(stats))
+	for name := range stats {
+		names = append(names, name)
+	}
+	sort.Strings(names)
+
+	tiers := make([]TierStatsModel, 0, len(names))
+	for _, name := range names {
+		stat := stats[name]
+		tiers = append(tiers, TierStatsModel{
+			Name:        types.StringValue(name),
+			NumObjects:  types.Int64Value(stat.NumObjects),
+			NumVersions: types.Int64Value(stat.NumVersions),
+			TotalSize:   types.Int64Value(stat.TotalSize),
+		})
+	}
+
+	elementType := types.ObjectType{AttrTypes: map[string]attr.Type{
+		"name":         types.StringType,
+		"num_objects":  types.Int64Type,
+		"num_versions": types.Int64Type,
+		"total_size":   types.Int64Type,
+	}}
+	tiersValue, diags := types.ListValueFrom(ctx, elementType, tiers)
+	resp.Diagnostics.Append(diags...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	config.ID = types.StringValue("tier-stats")
+	config.Tiers = tiersValue
+	resp.Diagnostics.Append(resp.State.Set(ctx, &config)...)
+}

--- a/provider/rustfs_ilm_tier_stats_datasource_test.go
+++ b/provider/rustfs_ilm_tier_stats_datasource_test.go
@@ -1,0 +1,50 @@
+package provider
+
+import (
+	"context"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-framework/datasource"
+	"github.com/hashicorp/terraform-plugin-framework/datasource/schema"
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+)
+
+func TestIlmTierStatsDataSourceSchema(t *testing.T) {
+	d := NewIlmTierStatsDataSource()
+	resp := &datasource.SchemaResponse{}
+	d.Schema(context.Background(), datasource.SchemaRequest{}, resp)
+	if resp.Diagnostics.HasError() {
+		t.Fatalf("schema diagnostics: %s", resp.Diagnostics)
+	}
+	for _, attr := range []string{"id", "tiers"} {
+		if _, ok := resp.Schema.Attributes[attr]; !ok {
+			t.Errorf("missing schema attribute %q", attr)
+		}
+	}
+	nested, ok := resp.Schema.Attributes["tiers"].(schema.ListNestedAttribute)
+	if !ok {
+		t.Fatalf("tiers attribute is not a ListNestedAttribute")
+	}
+	for _, attr := range []string{"name", "num_objects", "num_versions", "total_size"} {
+		if _, ok := nested.NestedObject.Attributes[attr]; !ok {
+			t.Errorf("missing nested schema attribute %q", attr)
+		}
+	}
+}
+
+func TestAccIlmTierStatsDataSource(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccProviderConfig() + `
+data "rustfs_ilm_tier_stats" "test" {}
+`,
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttrSet("data.rustfs_ilm_tier_stats.test", "id"),
+				),
+			},
+		},
+	})
+}


### PR DESCRIPTION
**Issue:** https://github.com/weinmann-emt/terraform-provider-rustfs/issues/108

Add a `rustfs_ilm_tier_stats` data source exposing per-tier usage statistics.

Closes #108

## Changes
- `pkg/rustfs/tier.go`: `TierStats()` (`GET /rustfs/admin/v3/tier-stats`).
- `provider/rustfs_ilm_tier_stats_datasource.go`, registered in `DataSources()`.
- Unit (httptest) + acceptance tests; docs + example.

## Testing
- `go build`, `go vet`, gofmt clean; golangci-lint no new findings.
- httptest unit tests + acceptance test pass against a live RustFS.

## Note
Verified against the live server: `/tier-stats` returns a flat map `{"<tier>":{"total_size":..,"num_versions":..,"num_objects":..}}` (the plan's assumed `TierStats`/`TotalVersionsSize` shape does not exist); schema follows the real response.
