### PR TITLE
feat: add rustfs_remote_target resource (#109)

### DIFF
--- a/docs/resources/remote_target.md
+++ b/docs/resources/remote_target.md
@@ -1,0 +1,67 @@
+---
+page_title: "rustfs_remote_target Resource - rustfs"
+description: |-
+  Manage remote targets used as replication destinations or notification ARNs
+---
+
+# rustfs_remote_target (Resource)
+
+Manage remote targets used as replication destinations or notification ARNs in rustfs.
+
+The remote target is registered on a source bucket. The server assigns the ARN.
+`set-remote-target` requires the remote endpoint to be reachable from the rustfs
+server and the destination bucket to exist on it, so the remote must be
+operational before this resource can be created.
+
+## Example Usage
+
+```terraform
+resource "rustfs_bucket" "source" {
+  name = "source-bucket"
+}
+
+resource "rustfs_bucket_versioning" "source" {
+  bucket = rustfs_bucket.source.name
+  status = "Enabled"
+}
+
+resource "rustfs_remote_target" "peer" {
+  type          = "replication"
+  endpoint      = "https://peer.example.com"
+  access_key    = "peeruser"
+  secret_key    = "peersecret"
+  secure        = true
+  bucket        = rustfs_bucket.source.name
+  target_bucket = "backup"
+  depends_on    = [rustfs_bucket_versioning.source]
+}
+```
+
+## Schema
+
+### Required
+
+- `access_key` (String, Sensitive) Access key for the remote target.
+- `bucket` (String) Source bucket on which the remote target is registered. Changing this forces a new resource to be created.
+- `endpoint` (String) Endpoint of the remote target, reachable from the rustfs server.
+- `secret_key` (String, Sensitive) Secret key for the remote target.
+- `target_bucket` (String) Destination bucket on the remote target. Changing this forces a new resource to be created.
+
+### Optional
+
+- `path` (String) Path prefix on the remote target.
+- `region` (String) Region of the remote target.
+- `secure` (Boolean) Use TLS for the remote target connection. Defaults to `true`.
+- `type` (String) Remote target type. Only `replication` is supported by this server version. Defaults to `replication`.
+
+### Read-Only
+
+- `arn` (String) ARN assigned by the server to the remote target.
+
+## Import
+
+Import is supported using the source bucket and ARN, separated by a colon:
+
+```
+terraform import rustfs_remote_target.my_target source-bucket:arn:minio:replication::d05cb765-0e40-4f59-b7d5-c88ca51cd0b4:backup
+```

--- a/examples/resources/rustfs_remote_target/resource.tf
+++ b/examples/resources/rustfs_remote_target/resource.tf
@@ -1,0 +1,19 @@
+resource "rustfs_bucket" "source" {
+  name = "source-bucket"
+}
+
+resource "rustfs_bucket_versioning" "source" {
+  bucket = rustfs_bucket.source.name
+  status = "Enabled"
+}
+
+resource "rustfs_remote_target" "peer" {
+  type          = "replication"
+  endpoint      = "https://peer.example.com"
+  access_key    = "peeruser"
+  secret_key    = var.peer_secret
+  secure        = true
+  bucket        = rustfs_bucket.source.name
+  target_bucket = "backup"
+  depends_on    = [rustfs_bucket_versioning.source]
+}

--- a/pkg/rustfs/remote_target.go
+++ b/pkg/rustfs/remote_target.go
@@ -1,0 +1,103 @@
+package rustfs
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"net/url"
+	"strings"
+)
+
+// RemoteTargetCredentials holds the access credentials for a remote target.
+type RemoteTargetCredentials struct {
+	AccessKey string `json:"accessKey"`
+	SecretKey string `json:"secretKey"`
+}
+
+// RemoteTarget describes a remote replication target registered on a source
+// bucket. The ARN is assigned by the server and never read back from list.
+type RemoteTarget struct {
+	Arn          string                   `json:"arn,omitempty"`
+	Type         string                   `json:"type"`
+	Endpoint     string                   `json:"endpoint"`
+	Secure       bool                     `json:"secure"`
+	Region       string                   `json:"region,omitempty"`
+	Path         string                   `json:"path,omitempty"`
+	SourceBucket string                   `json:"sourcebucket,omitempty"`
+	TargetBucket string                   `json:"targetbucket"`
+	Credentials  *RemoteTargetCredentials `json:"credentials,omitempty"`
+}
+
+// AddRemoteTarget registers (or, when the ARN is set, updates) a remote target
+// on the given source bucket and returns the server-assigned ARN.
+func (c *RustfsAdmin) AddRemoteTarget(bucket string, target RemoteTarget) (string, error) {
+	body, err := json.Marshal(target)
+	if err != nil {
+		return "", err
+	}
+	query := url.Values{"bucket": []string{bucket}}
+	// When the caller knows the ARN it is an update: the server only applies a
+	// create-path PUT when the target does not already exist (it returns the
+	// existing ARN otherwise). To actually persist the new field values the
+	// request must be an explicit `update=true` with the `creds` operation group.
+	if target.Arn != "" {
+		query.Set("update", "true")
+		query.Set("creds", "true")
+	}
+	reqData := RequestData{
+		Method:      "PUT",
+		RelPath:     "set-remote-target",
+		QueryValues: query,
+		Content:     body,
+	}
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	resp, err := c.doRequest(ctx, reqData)
+	if err != nil {
+		return "", err
+	}
+	defer resp.Body.Close()
+	bytes, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return "", err
+	}
+	return strings.Trim(string(bytes), "\"\n"), nil
+}
+
+// ListRemoteTargets returns the remote targets registered on the given source
+// bucket.
+func (c *RustfsAdmin) ListRemoteTargets(bucket string) ([]RemoteTarget, error) {
+	reqData := RequestData{
+		Method:      "GET",
+		RelPath:     "list-remote-targets",
+		QueryValues: url.Values{"bucket": []string{bucket}},
+	}
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	resp, err := c.doRequest(ctx, reqData)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+	var targets []RemoteTarget
+	err = json.NewDecoder(resp.Body).Decode(&targets)
+	return targets, err
+}
+
+// DeleteRemoteTarget removes the remote target identified by arn from the given
+// source bucket.
+func (c *RustfsAdmin) DeleteRemoteTarget(bucket, arn string) error {
+	reqData := RequestData{
+		Method:      "DELETE",
+		RelPath:     "remove-remote-target",
+		QueryValues: url.Values{"bucket": []string{bucket}, "arn": []string{arn}},
+	}
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	resp, err := c.doRequest(ctx, reqData)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+	return nil
+}

--- a/pkg/rustfs/remote_target_test.go
+++ b/pkg/rustfs/remote_target_test.go
@@ -1,0 +1,152 @@
+package rustfs
+
+import (
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+func TestAddRemoteTarget(t *testing.T) {
+	var gotPath, gotBody string
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPut {
+			t.Errorf("expected PUT, got %s", r.Method)
+		}
+		if !strings.Contains(r.URL.RawQuery, "bucket=src-bkt") {
+			t.Errorf("expected bucket query param, got %s", r.URL.RawQuery)
+		}
+		if strings.Contains(r.URL.RawQuery, "update=") {
+			t.Errorf("create request must not carry update param, got %s", r.URL.RawQuery)
+		}
+		gotPath = r.URL.Path
+		bodyBytes, _ := io.ReadAll(r.Body)
+		gotBody = string(bodyBytes)
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`"arn:minio:replication::abc:dst-bkt"`))
+	}))
+	defer server.Close()
+	c := New(&RustfsAdminConfig{
+		AccessKey:    "admin",
+		AccessSecret: "secret",
+		Endpoint:     strings.TrimPrefix(server.URL, "http://"),
+	})
+	target := RemoteTarget{
+		Type:         "replication",
+		Endpoint:     "https://peer.example.com",
+		Secure:       true,
+		TargetBucket: "dst-bkt",
+		Credentials: &RemoteTargetCredentials{
+			AccessKey: "peeruser",
+			SecretKey: "peersecret",
+		},
+	}
+	arn, err := c.AddRemoteTarget("src-bkt", target)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if arn != "arn:minio:replication::abc:dst-bkt" {
+		t.Errorf("unexpected arn: %s", arn)
+	}
+	if !strings.Contains(gotPath, "/set-remote-target") {
+		t.Errorf("wrong path: %s", gotPath)
+	}
+	if !strings.Contains(gotBody, `"type":"replication"`) ||
+		!strings.Contains(gotBody, `"targetbucket":"dst-bkt"`) ||
+		!strings.Contains(gotBody, `"accessKey":"peeruser"`) {
+		t.Errorf("wrong body: %s", gotBody)
+	}
+}
+
+func TestUpdateRemoteTarget(t *testing.T) {
+	var gotQuery string
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPut {
+			t.Errorf("expected PUT, got %s", r.Method)
+		}
+		gotQuery = r.URL.RawQuery
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`"arn:minio:replication::abc:dst-bkt"`))
+	}))
+	defer server.Close()
+	c := New(&RustfsAdminConfig{
+		AccessKey:    "admin",
+		AccessSecret: "secret",
+		Endpoint:     strings.TrimPrefix(server.URL, "http://"),
+	})
+	target := RemoteTarget{
+		Arn:          "arn:minio:replication::abc:dst-bkt",
+		Type:         "replication",
+		Endpoint:     "https://peer.example.com",
+		Secure:       true,
+		TargetBucket: "dst-bkt",
+		Credentials: &RemoteTargetCredentials{
+			AccessKey: "peeruser",
+			SecretKey: "peersecret",
+		},
+	}
+	if _, err := c.AddRemoteTarget("src-bkt", target); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !strings.Contains(gotQuery, "update=true") {
+		t.Errorf("expected update=true, got %s", gotQuery)
+	}
+	if !strings.Contains(gotQuery, "creds=true") {
+		t.Errorf("expected creds=true, got %s", gotQuery)
+	}
+}
+
+func TestListRemoteTargets(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodGet {
+			t.Errorf("expected GET, got %s", r.Method)
+		}
+		if !strings.Contains(r.URL.Path, "/list-remote-targets") {
+			t.Errorf("wrong path: %s", r.URL.Path)
+		}
+		if !strings.Contains(r.URL.RawQuery, "bucket=src-bkt") {
+			t.Errorf("expected bucket query param, got %s", r.URL.RawQuery)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`[{"sourcebucket":"src-bkt","arn":"arn:minio:replication:::peer:backup","type":"replication","endpoint":"https://peer.example.com","secure":true,"targetbucket":"backup"}]`))
+	}))
+	defer server.Close()
+	c := New(&RustfsAdminConfig{
+		AccessKey:    "admin",
+		AccessSecret: "secret",
+		Endpoint:     strings.TrimPrefix(server.URL, "http://"),
+	})
+	targets, err := c.ListRemoteTargets("src-bkt")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(targets) != 1 || targets[0].Arn != "arn:minio:replication:::peer:backup" {
+		t.Errorf("unexpected targets: %+v", targets)
+	}
+}
+
+func TestDeleteRemoteTarget(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodDelete {
+			t.Errorf("expected DELETE, got %s", r.Method)
+		}
+		if !strings.Contains(r.URL.Path, "/remove-remote-target") {
+			t.Errorf("wrong path: %s", r.URL.Path)
+		}
+		if !strings.Contains(r.URL.RawQuery, "bucket=src-bkt") ||
+			!strings.Contains(r.URL.RawQuery, "arn=arn%3Aminio%3Areplication%3A%3Aabc%3Adst-bkt") {
+			t.Errorf("unexpected query: %s", r.URL.RawQuery)
+		}
+		w.WriteHeader(http.StatusNoContent)
+	}))
+	defer server.Close()
+	c := New(&RustfsAdminConfig{
+		AccessKey:    "admin",
+		AccessSecret: "secret",
+		Endpoint:     strings.TrimPrefix(server.URL, "http://"),
+	})
+	if err := c.DeleteRemoteTarget("src-bkt", "arn:minio:replication::abc:dst-bkt"); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}

--- a/provider/provider.go
+++ b/provider/provider.go
@@ -137,6 +137,7 @@ func (p *RustfsProvider) Resources(ctx context.Context) []func() resource.Resour
 		NewBucketReplicationResource,
 		NewBucketEncryptionResource,
 		NewBucketVersioningResource,
+		NewRemoteTargetRessource,
 	}
 }
 

--- a/provider/rustfs_remote_target_ressource.go
+++ b/provider/rustfs_remote_target_ressource.go
@@ -1,0 +1,250 @@
+package provider
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/hashicorp/terraform-plugin-framework/path"
+	"github.com/hashicorp/terraform-plugin-framework/resource"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/booldefault"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringdefault"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/weinmann-emt/terraform-provider-rustfs/pkg/rustfs"
+)
+
+var (
+	_ resource.Resource                = &RemoteTargetRessource{}
+	_ resource.ResourceWithImportState = &RemoteTargetRessource{}
+)
+
+// RemoteTargetRessource manages remote targets used as replication destinations
+// or notification ARNs in rustfs.
+type RemoteTargetRessource struct {
+	client *AllClient
+}
+
+type RemoteTargetRessourceModel struct {
+	Arn          types.String `tfsdk:"arn"`
+	Type         types.String `tfsdk:"type"`
+	Endpoint     types.String `tfsdk:"endpoint"`
+	AccessKey    types.String `tfsdk:"access_key"`
+	SecretKey    types.String `tfsdk:"secret_key"`
+	Secure       types.Bool   `tfsdk:"secure"`
+	Region       types.String `tfsdk:"region"`
+	Path         types.String `tfsdk:"path"`
+	Bucket       types.String `tfsdk:"bucket"`
+	TargetBucket types.String `tfsdk:"target_bucket"`
+}
+
+// NewRemoteTargetRessource returns a new RemoteTargetRessource.
+func NewRemoteTargetRessource() resource.Resource {
+	return &RemoteTargetRessource{}
+}
+
+func (r *RemoteTargetRessource) Metadata(_ context.Context, req resource.MetadataRequest, resp *resource.MetadataResponse) {
+	resp.TypeName = req.ProviderTypeName + "_remote_target"
+}
+
+func (r *RemoteTargetRessource) Schema(_ context.Context, _ resource.SchemaRequest, resp *resource.SchemaResponse) {
+	resp.Schema = schema.Schema{
+		Description:         "Manage remote targets used as replication destinations or notification ARNs in rustfs",
+		MarkdownDescription: "Manage remote targets used as replication destinations or notification ARNs in rustfs",
+		Attributes: map[string]schema.Attribute{
+			"arn": schema.StringAttribute{
+				Computed:    true,
+				Description: "ARN assigned by the server to the remote target.",
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.UseStateForUnknown(),
+				},
+			},
+			"type": schema.StringAttribute{
+				Optional:    true,
+				Computed:    true,
+				Default:     stringdefault.StaticString("replication"),
+				Description: "Remote target type. Only 'replication' is supported by this server version.",
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.RequiresReplace(),
+				},
+			},
+			"endpoint": schema.StringAttribute{
+				Required:    true,
+				Description: "Endpoint of the remote target, reachable from the rustfs server.",
+			},
+			"access_key": schema.StringAttribute{
+				Required:    true,
+				Sensitive:   true,
+				Description: "Access key for the remote target.",
+			},
+			"secret_key": schema.StringAttribute{
+				Required:    true,
+				Sensitive:   true,
+				Description: "Secret key for the remote target.",
+			},
+			"secure": schema.BoolAttribute{
+				Optional:    true,
+				Computed:    true,
+				Default:     booldefault.StaticBool(true),
+				Description: "Use TLS for the remote target connection. Defaults to true.",
+			},
+			"region": schema.StringAttribute{
+				Optional:    true,
+				Description: "Region of the remote target.",
+			},
+			"path": schema.StringAttribute{
+				Optional:    true,
+				Description: "Path prefix on the remote target.",
+			},
+			"bucket": schema.StringAttribute{
+				Required:    true,
+				Description: "Source bucket on which the remote target is registered.",
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.RequiresReplace(),
+				},
+			},
+			"target_bucket": schema.StringAttribute{
+				Required:    true,
+				Description: "Destination bucket on the remote target.",
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.RequiresReplace(),
+				},
+			},
+		},
+	}
+}
+
+func (r *RemoteTargetRessource) Configure(_ context.Context, req resource.ConfigureRequest, resp *resource.ConfigureResponse) {
+	if req.ProviderData == nil {
+		return
+	}
+	client, ok := req.ProviderData.(*AllClient)
+	if !ok {
+		resp.Diagnostics.AddError(
+			"Unexpected Resource Configure Type",
+			fmt.Sprintf("Expected *AllClient, got: %T. Please report this issue to the provider developers.", req.ProviderData),
+		)
+		return
+	}
+	r.client = client
+}
+
+func (r *RemoteTargetRessource) Create(ctx context.Context, req resource.CreateRequest, resp *resource.CreateResponse) {
+	var plan RemoteTargetRessourceModel
+	resp.Diagnostics.Append(req.Plan.Get(ctx, &plan)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	arn, err := r.client.RustClient.AddRemoteTarget(plan.Bucket.ValueString(), r.targetFromModel(plan))
+	if err != nil {
+		resp.Diagnostics.AddError("Error creating remote target", err.Error())
+		return
+	}
+	plan.Arn = types.StringValue(arn)
+	resp.Diagnostics.Append(resp.State.Set(ctx, &plan)...)
+}
+
+func (r *RemoteTargetRessource) Read(ctx context.Context, req resource.ReadRequest, resp *resource.ReadResponse) {
+	var state RemoteTargetRessourceModel
+	resp.Diagnostics.Append(req.State.Get(ctx, &state)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	targets, err := r.client.RustClient.ListRemoteTargets(state.Bucket.ValueString())
+	if err != nil {
+		resp.Diagnostics.AddError("Error listing remote targets", err.Error())
+		return
+	}
+	var found *rustfs.RemoteTarget
+	for i := range targets {
+		if targets[i].Arn == state.Arn.ValueString() {
+			found = &targets[i]
+			break
+		}
+	}
+	if found == nil {
+		resp.State.RemoveResource(ctx)
+		return
+	}
+	state.Arn = types.StringValue(found.Arn)
+	state.Endpoint = types.StringValue(found.Endpoint)
+	state.Secure = types.BoolValue(found.Secure)
+	if found.Region != "" {
+		state.Region = types.StringValue(found.Region)
+	} else {
+		state.Region = types.StringNull()
+	}
+	if found.Path != "" {
+		state.Path = types.StringValue(found.Path)
+	} else {
+		state.Path = types.StringNull()
+	}
+	state.TargetBucket = types.StringValue(found.TargetBucket)
+	if found.Credentials != nil {
+		state.AccessKey = types.StringValue(found.Credentials.AccessKey)
+	}
+	resp.Diagnostics.Append(resp.State.Set(ctx, &state)...)
+}
+
+func (r *RemoteTargetRessource) Update(ctx context.Context, req resource.UpdateRequest, resp *resource.UpdateResponse) {
+	var plan, state RemoteTargetRessourceModel
+	resp.Diagnostics.Append(req.Plan.Get(ctx, &plan)...)
+	resp.Diagnostics.Append(req.State.Get(ctx, &state)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	target := r.targetFromModel(plan)
+	target.Arn = state.Arn.ValueString()
+	if _, err := r.client.RustClient.AddRemoteTarget(plan.Bucket.ValueString(), target); err != nil {
+		resp.Diagnostics.AddError("Error updating remote target", err.Error())
+		return
+	}
+	plan.Arn = state.Arn
+	resp.Diagnostics.Append(resp.State.Set(ctx, &plan)...)
+}
+
+func (r *RemoteTargetRessource) Delete(ctx context.Context, req resource.DeleteRequest, resp *resource.DeleteResponse) {
+	var data RemoteTargetRessourceModel
+	resp.Diagnostics.Append(req.State.Get(ctx, &data)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+	if err := r.client.RustClient.DeleteRemoteTarget(data.Bucket.ValueString(), data.Arn.ValueString()); err != nil {
+		resp.Diagnostics.AddError("Error deleting remote target", err.Error())
+	}
+}
+
+func (r *RemoteTargetRessource) ImportState(ctx context.Context, req resource.ImportStateRequest, resp *resource.ImportStateResponse) {
+	// Import ID is the composite "<source-bucket>:<arn>".
+	id := req.ID
+	parts := strings.SplitN(id, ":", 2)
+	if len(parts) != 2 {
+		resp.Diagnostics.AddError(
+			"Invalid import ID",
+			"Expected import ID in the format <source-bucket>:<arn>",
+		)
+		return
+	}
+	resp.Diagnostics.Append(resp.State.SetAttribute(ctx, path.Root("bucket"), parts[0])...)
+	resp.Diagnostics.Append(resp.State.SetAttribute(ctx, path.Root("arn"), parts[1])...)
+}
+
+func (r *RemoteTargetRessource) targetFromModel(plan RemoteTargetRessourceModel) rustfs.RemoteTarget {
+	return rustfs.RemoteTarget{
+		Type:         plan.Type.ValueString(),
+		Endpoint:     plan.Endpoint.ValueString(),
+		Secure:       plan.Secure.ValueBool(),
+		Region:       plan.Region.ValueString(),
+		Path:         plan.Path.ValueString(),
+		TargetBucket: plan.TargetBucket.ValueString(),
+		Credentials: &rustfs.RemoteTargetCredentials{
+			AccessKey: plan.AccessKey.ValueString(),
+			SecretKey: plan.SecretKey.ValueString(),
+		},
+	}
+}

--- a/provider/rustfs_remote_target_ressource_test.go
+++ b/provider/rustfs_remote_target_ressource_test.go
@@ -1,0 +1,149 @@
+package provider
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"testing"
+
+	fwresource "github.com/hashicorp/terraform-plugin-framework/resource"
+	"github.com/hashicorp/terraform-plugin-testing/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/terraform"
+	"github.com/minio/minio-go/v7"
+	"github.com/minio/minio-go/v7/pkg/credentials"
+)
+
+// remoteTargetPeer returns the peer connection settings required to exercise
+// rustfs_remote_target. Because set-remote-target validates that the remote
+// endpoint is reachable and the destination bucket exists, a second running
+// rustfs peer is required. When it is not configured the test is skipped.
+type remoteTargetPeer struct {
+	endpoint   string // endpoint reachable from the rustfs server
+	s3Endpoint string // endpoint reachable from the test host for bucket setup
+	accessKey  string
+	secretKey  string
+}
+
+func remoteTargetPeerConfig(t *testing.T) (*remoteTargetPeer, error) {
+	t.Helper()
+	p := &remoteTargetPeer{
+		endpoint:  os.Getenv("RUSTFS_PEER_ENDPOINT"),
+		accessKey: os.Getenv("RUSTFS_PEER_ACCESS_KEY"),
+		secretKey: os.Getenv("RUSTFS_PEER_SECRET_KEY"),
+	}
+	if p.endpoint == "" || p.accessKey == "" || p.secretKey == "" {
+		return nil, fmt.Errorf("RUSTFS_PEER_ENDPOINT, RUSTFS_PEER_ACCESS_KEY and RUSTFS_PEER_SECRET_KEY must be set")
+	}
+	if v := os.Getenv("RUSTFS_PEER_S3_ENDPOINT"); v != "" {
+		p.s3Endpoint = v
+	} else {
+		p.s3Endpoint = p.endpoint
+	}
+	return p, nil
+}
+
+func TestRemoteTargetRessourceSchema(t *testing.T) {
+	r := NewRemoteTargetRessource()
+	resp := &fwresource.SchemaResponse{}
+	r.Schema(context.Background(), fwresource.SchemaRequest{}, resp)
+	if resp.Diagnostics.HasError() {
+		t.Fatalf("schema diagnostics: %s", resp.Diagnostics)
+	}
+	for _, attr := range []string{"arn", "type", "endpoint", "access_key", "secret_key", "secure", "region", "path", "bucket", "target_bucket"} {
+		if _, ok := resp.Schema.Attributes[attr]; !ok {
+			t.Errorf("missing schema attribute %q", attr)
+		}
+	}
+}
+
+func TestAccRemoteTargetResource(t *testing.T) {
+	peer, err := remoteTargetPeerConfig(t)
+	if err != nil {
+		t.Skipf("skipping remote target acceptance test: %v", err)
+	}
+
+	// The source bucket must be versioned and the destination bucket must
+	// exist on the (versioned) peer for set-remote-target to succeed.
+	srcBucket := fmt.Sprintf("tf-rt-src-%d", acctest.RandInt())
+	dstBucket := fmt.Sprintf("tf-rt-dst-%d", acctest.RandInt())
+
+	srcClient, err := testAccMinioClient()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := srcClient.MakeBucket(context.Background(), srcBucket, minio.MakeBucketOptions{}); err != nil {
+		t.Fatalf("creating source bucket: %v", err)
+	}
+	t.Cleanup(func() { _ = srcClient.RemoveBucket(context.Background(), srcBucket) })
+	if err := srcClient.SetBucketVersioning(context.Background(), srcBucket, minio.BucketVersioningConfiguration{Status: "Enabled"}); err != nil {
+		t.Fatalf("enabling versioning on source bucket: %v", err)
+	}
+
+	peerClient, err := minio.New(peer.s3Endpoint, &minio.Options{
+		Creds:  credentials.NewStaticV4(peer.accessKey, peer.secretKey, ""),
+		Secure: false,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := peerClient.MakeBucket(context.Background(), dstBucket, minio.MakeBucketOptions{}); err != nil {
+		t.Fatalf("creating destination bucket on peer: %v", err)
+	}
+	t.Cleanup(func() { _ = peerClient.RemoveBucket(context.Background(), dstBucket) })
+	if err := peerClient.SetBucketVersioning(context.Background(), dstBucket, minio.BucketVersioningConfiguration{Status: "Enabled"}); err != nil {
+		t.Fatalf("enabling versioning on destination bucket: %v", err)
+	}
+
+	resourceName := "rustfs_remote_target.test"
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccRemoteTargetConfig(srcBucket, dstBucket, peer, "false"),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceName, "type", "replication"),
+					resource.TestCheckResourceAttr(resourceName, "bucket", srcBucket),
+					resource.TestCheckResourceAttr(resourceName, "target_bucket", dstBucket),
+					resource.TestCheckResourceAttrSet(resourceName, "arn"),
+				),
+			},
+			{
+				ResourceName: resourceName,
+				ImportState:  true,
+				ImportStateIdFunc: func(s *terraform.State) (string, error) {
+					rs, ok := s.RootModule().Resources[resourceName]
+					if !ok {
+						return "", fmt.Errorf("not found: %s", resourceName)
+					}
+					return rs.Primary.Attributes["bucket"] + ":" + rs.Primary.Attributes["arn"], nil
+				},
+				ImportStateVerifyIdentifierAttribute: "arn",
+				ImportStateVerify:                    true,
+				ImportStateVerifyIgnore:              []string{"secret_key"},
+			},
+			{
+				Config: testAccRemoteTargetConfig(srcBucket, dstBucket, peer, "true"),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceName, "secure", "true"),
+					resource.TestCheckResourceAttrSet(resourceName, "arn"),
+				),
+			},
+		},
+	})
+}
+
+func testAccRemoteTargetConfig(srcBucket, dstBucket string, peer *remoteTargetPeer, secure string) string {
+	return testAccProviderConfig() + fmt.Sprintf(`
+resource "rustfs_remote_target" "test" {
+  type          = "replication"
+  endpoint      = "%s"
+  access_key    = "%s"
+  secret_key    = "%s"
+  secure        = %s
+  bucket        = "%s"
+  target_bucket = "%s"
+}
+`, peer.endpoint, peer.accessKey, peer.secretKey, secure, srcBucket, dstBucket)
+}


### PR DESCRIPTION
**Issue:** https://github.com/weinmann-emt/terraform-provider-rustfs/issues/109

Add a `rustfs_remote_target` resource to register remote targets used as replication destinations.

Closes #109

## Changes
- `pkg/rustfs/remote_target.go`: client for the verified endpoints `list-remote-targets`, `set-remote-target`, `remove-remote-target`.
- `provider/rustfs_remote_target_ressource.go` (`bucket` + `target_bucket` model, import as `<source-bucket>:<arn>`), registered in `Resources()`.
- Unit (httptest) + acceptance tests; docs + example.

## Testing
- `go build`, `go vet`, gofmt clean; golangci-lint no new findings.
- httptest unit tests + schema tests pass.

## Note
The plan's API table was inaccurate — `target/list`, `target/arns` and `target/{type}/{name}` do not exist in RustFS; the real endpoints are `list-remote-targets` / `set-remote-target` / `remove-remote-target`. Create/update require a reachable versioned remote on a **separate host** (RustFS blocks loopback targets), so the acceptance test skips unless `RUSTFS_PEER_*` env vars are set; it cannot run end-to-end against a single localhost server.
