### PR TITLE
feat: add rustfs_server_info data source (#113)

### DIFF
--- a/docs/data-sources/server_info.md
+++ b/docs/data-sources/server_info.md
@@ -1,0 +1,94 @@
+---
+page_title: "rustfs_server_info Data Source - rustfs"
+description: |-
+  Exposes cluster, server, pool and drive information from the RustFS admin API.
+---
+
+# rustfs_server_info (Data Source)
+
+Exposes cluster, server, pool and drive information from the RustFS admin API (`GET /rustfs/admin/v3/info`).
+
+The data source exposes the most commonly used cluster attributes as first-class
+schema attributes, plus a `raw_json` attribute containing the full, unmodified
+JSON response for complete fidelity.
+
+## Example Usage
+
+```terraform
+data "rustfs_server_info" "cluster" {}
+
+output "cluster_mode"     { value = data.rustfs_server_info.cluster.mode }
+output "deployment_id"    { value = data.rustfs_server_info.cluster.deployment_id }
+output "server_versions"  { value = data.rustfs_server_info.cluster.servers[*].version }
+```
+
+## Schema
+
+### Read-Only
+
+- `backend_type` (String) Backend type (e.g. Erasure).
+- `bitrot_selftest` (String) Bitrot self test status.
+- `bucket_count` (Number) Number of buckets in the cluster.
+- `delete_marker_count` (Number) Number of delete markers in the cluster.
+- `deployment_id` (String) Cluster deployment ID.
+- `mode` (String) Cluster mode (e.g. online, offline).
+- `object_count` (Number) Number of objects in the cluster.
+- `offline_disks` (Number) Number of offline disks.
+- `online_disks` (Number) Number of online disks.
+- `pool_count` (Number) Number of storage pools in the cluster.
+- `pools` (Attributes List) Storage pools and their erasure sets. See [below](#nestedatt--pools).
+- `raw_json` (String) Full raw JSON response from the /info endpoint.
+- `region` (String) Cluster region, when configured.
+- `servers` (Attributes List) Server nodes in the cluster. See [below](#nestedatt--servers).
+- `total_drives_per_set` (List of Number) Total drives per erasure set.
+- `total_sets` (List of Number) Total number of erasure sets per pool.
+- `usage_size` (Number) Aggregate usage size in bytes.
+- `version_count` (Number) Number of object versions in the cluster.
+
+<a id="nestedatt--pools"></a>
+### Nested Schema for `pools`
+
+Read-Only:
+
+- `delete_markers_count` (Number)
+- `heal_disks` (Number)
+- `id` (Number)
+- `objects_count` (Number)
+- `pool_number` (Number)
+- `raw_capacity` (Number)
+- `raw_usage` (Number)
+- `set_number` (Number)
+- `usage` (Number)
+- `versions_count` (Number)
+
+<a id="nestedatt--servers"></a>
+### Nested Schema for `servers`
+
+Read-Only:
+
+- `drives` (Attributes List) Drives attached to this server. See [below](#nestedatt--servers--drives).
+- `endpoint` (String)
+- `max_procs` (Number)
+- `mem_alloc` (Number)
+- `mem_total_alloc` (Number)
+- `num_cpu` (Number)
+- `state` (String)
+- `uptime` (Number)
+- `version` (String)
+
+<a id="nestedatt--servers--drives"></a>
+### Nested Schema for `servers.drives`
+
+Read-Only:
+
+- `availspace` (Number)
+- `endpoint` (String)
+- `healing` (Boolean)
+- `local` (Boolean)
+- `path` (String)
+- `runtime_state` (String)
+- `state` (String)
+- `totalspace` (Number)
+- `usedspace` (Number)
+- `utilization` (Number)
+- `uuid` (String)

--- a/examples/data-sources/rustfs_server_info/data-source.tf
+++ b/examples/data-sources/rustfs_server_info/data-source.tf
@@ -1,0 +1,13 @@
+data "rustfs_server_info" "cluster" {}
+
+output "cluster_mode" {
+  value = data.rustfs_server_info.cluster.mode
+}
+
+output "deployment_id" {
+  value = data.rustfs_server_info.cluster.deployment_id
+}
+
+output "server_versions" {
+  value = data.rustfs_server_info.cluster.servers[*].version
+}

--- a/pkg/rustfs/info.go
+++ b/pkg/rustfs/info.go
@@ -1,0 +1,115 @@
+package rustfs
+
+import (
+	"context"
+	"encoding/json"
+)
+
+// ServerInfo is the response of the GET /v3/info endpoint.
+type ServerInfo struct {
+	AdminDiscovery map[string]string `json:"admin_discovery"`
+	BitrotSelftest string            `json:"bitrotSelftest"`
+	Info           ClusterInfo       `json:"info"`
+}
+
+// ClusterInfo holds the cluster level information.
+type ClusterInfo struct {
+	Backend       BackendInfo                       `json:"backend"`
+	Buckets       CountInfo                         `json:"buckets"`
+	Deletemarkers CountInfo                         `json:"deletemarkers"`
+	DeploymentID  string                            `json:"deploymentID"`
+	Mode          string                            `json:"mode"`
+	Objects       CountInfo                         `json:"objects"`
+	Pools         map[string]map[string]PoolSetInfo `json:"pools"`
+	Region        *string                           `json:"region"`
+	Servers       []ServerEntry                     `json:"servers"`
+	Usage         UsageInfo                         `json:"usage"`
+	Versions      CountInfo                         `json:"versions"`
+}
+
+// BackendInfo describes the erasure / parity configuration of the cluster.
+type BackendInfo struct {
+	BackendType       string  `json:"backendType"`
+	OfflineDisks      int64   `json:"offlineDisks"`
+	OnlineDisks       int64   `json:"onlineDisks"`
+	RRSCParity        int64   `json:"rrSCParity"`
+	StandardSCParity  int64   `json:"standardSCParity"`
+	TotalDrivesPerSet []int64 `json:"totalDrivesPerSet"`
+	TotalSets         []int64 `json:"totalSets"`
+	UnknownDisks      int64   `json:"unknownDisks"`
+}
+
+// CountInfo is a counter with an optional error field.
+type CountInfo struct {
+	Count int64 `json:"count"`
+}
+
+// UsageInfo describes aggregate usage.
+type UsageInfo struct {
+	Size int64 `json:"size"`
+}
+
+// ServerEntry describes a single server node in the cluster.
+type ServerEntry struct {
+	CommitID string      `json:"commitID"`
+	Drives   []DriveInfo `json:"drives"`
+	Endpoint string      `json:"endpoint"`
+	MaxProcs int         `json:"max_procs"`
+	MemStats MemStats    `json:"mem_stats"`
+	NumCPU   int         `json:"num_cpu"`
+	State    string      `json:"state"`
+	Uptime   int64       `json:"uptime"`
+	Version  string      `json:"version"`
+}
+
+// DriveInfo describes a single drive attached to a server node.
+type DriveInfo struct {
+	Availspace   int64   `json:"availspace"`
+	Endpoint     string  `json:"endpoint"`
+	Healing      bool    `json:"healing"`
+	Local        bool    `json:"local"`
+	Path         string  `json:"path"`
+	RuntimeState string  `json:"runtimeState"`
+	State        string  `json:"state"`
+	Totalspace   int64   `json:"totalspace"`
+	Usedspace    int64   `json:"usedspace"`
+	UUID         string  `json:"uuid"`
+	Utilization  float64 `json:"utilization"`
+}
+
+// MemStats describes the Go runtime memory statistics of a server node.
+type MemStats struct {
+	Alloc      uint64 `json:"alloc"`
+	TotalAlloc uint64 `json:"total_alloc"`
+	HeapAlloc  uint64 `json:"heap_alloc"`
+}
+
+// PoolSetInfo describes a single erasure set within a storage pool.
+type PoolSetInfo struct {
+	DeleteMarkersCount int64 `json:"deleteMarkersCount"`
+	HealDisks          int64 `json:"healDisks"`
+	ID                 int64 `json:"id"`
+	ObjectsCount       int64 `json:"objectsCount"`
+	RawCapacity        int64 `json:"rawCapacity"`
+	RawUsage           int64 `json:"rawUsage"`
+	Usage              int64 `json:"usage"`
+	VersionsCount      int64 `json:"versionsCount"`
+}
+
+// ServerInfo returns cluster and server information from GET /v3/info.
+func (c *RustfsAdmin) ServerInfo() (ServerInfo, error) {
+	reqData := RequestData{
+		Method:  "GET",
+		RelPath: "info",
+	}
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	resp, err := c.doRequest(ctx, reqData)
+	if err != nil {
+		return ServerInfo{}, err
+	}
+	defer resp.Body.Close()
+	var info ServerInfo
+	err = json.NewDecoder(resp.Body).Decode(&info)
+	return info, err
+}

--- a/pkg/rustfs/info_test.go
+++ b/pkg/rustfs/info_test.go
@@ -1,0 +1,161 @@
+package rustfs
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func TestServerInfo(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodGet {
+			t.Errorf("expected GET, got %s", r.Method)
+		}
+		if r.URL.Path != "/rustfs/admin/v3/info" {
+			t.Errorf("expected path /rustfs/admin/v3/info, got %s", r.URL.Path)
+		}
+		w.WriteHeader(http.StatusOK)
+		if err := json.NewEncoder(w).Encode(sampleServerInfoPayload()); err != nil {
+			t.Errorf("error encoding payload: %v", err)
+		}
+	}))
+	defer server.Close()
+
+	client := New(&RustfsAdminConfig{
+		Endpoint:  server.Listener.Addr().String(),
+		AccessKey: "admin",
+	})
+	client.accessSecret = "secret"
+
+	info, err := client.ServerInfo()
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if info.Info.Mode != "online" {
+		t.Errorf("expected mode online, got %q", info.Info.Mode)
+	}
+	if info.Info.DeploymentID != "3d6a83f0-8b13-49e0-bd0e-3a921f256a6c" {
+		t.Errorf("unexpected deployment id %q", info.Info.DeploymentID)
+	}
+	if len(info.Info.Servers) != 1 {
+		t.Fatalf("expected 1 server, got %d", len(info.Info.Servers))
+	}
+	serverEntry := info.Info.Servers[0]
+	if serverEntry.Version != "2026-09-01T17:35:49Z@1.0.0-rc.5" {
+		t.Errorf("unexpected server version %q", serverEntry.Version)
+	}
+	if serverEntry.Uptime != 18986 {
+		t.Errorf("expected uptime 18986, got %d", serverEntry.Uptime)
+	}
+	if len(serverEntry.Drives) != 1 {
+		t.Fatalf("expected 1 drive, got %d", len(serverEntry.Drives))
+	}
+	if serverEntry.Drives[0].State != "ok" {
+		t.Errorf("expected drive state ok, got %q", serverEntry.Drives[0].State)
+	}
+	if info.Info.Backend.BackendType != "Erasure" {
+		t.Errorf("expected backend type Erasure, got %q", info.Info.Backend.BackendType)
+	}
+	if info.Info.Buckets.Count != 5 {
+		t.Errorf("expected 5 buckets, got %d", info.Info.Buckets.Count)
+	}
+	if info.Info.Usage.Size != 0 {
+		t.Errorf("expected usage size 0, got %d", info.Info.Usage.Size)
+	}
+}
+
+func sampleServerInfoPayload() map[string]interface{} {
+	return map[string]interface{}{
+		"admin_discovery": map[string]interface{}{
+			"clusterSnapshot":     "/rustfs/admin/v4/cluster/snapshot",
+			"extensionsCatalog":   "/rustfs/admin/v4/extensions/catalog",
+			"runtimeCapabilities": "/rustfs/admin/v4/runtime/capabilities",
+		},
+		"bitrotSelftest": "passed",
+		"info": map[string]interface{}{
+			"backend": map[string]interface{}{
+				"backendType":       "Erasure",
+				"offlineDisks":      0,
+				"onlineDisks":       1,
+				"rrSCParity":        0,
+				"standardSCParity":  0,
+				"totalDrivesPerSet": []interface{}{1},
+				"totalSets":         []interface{}{1},
+				"unknownDisks":      0,
+			},
+			"buckets": map[string]interface{}{
+				"count": 5,
+				"error": nil,
+			},
+			"deletemarkers": map[string]interface{}{
+				"count": 0,
+				"error": nil,
+			},
+			"deploymentID": "3d6a83f0-8b13-49e0-bd0e-3a921f256a6c",
+			"domain":       nil,
+			"mode":         "online",
+			"objects": map[string]interface{}{
+				"count": 0,
+				"error": nil,
+			},
+			"pools": map[string]interface{}{
+				"0": map[string]interface{}{
+					"0": map[string]interface{}{
+						"deleteMarkersCount": 0,
+						"healDisks":          0,
+						"id":                 0,
+						"objectsCount":       0,
+						"rawCapacity":        63728975872,
+						"rawUsage":           4699373568,
+						"usage":              0,
+						"versionsCount":      0,
+					},
+				},
+			},
+			"region": nil,
+			"servers": []interface{}{
+				map[string]interface{}{
+					"commitID": "",
+					"drives": []interface{}{
+						map[string]interface{}{
+							"availspace":   59029602304,
+							"endpoint":     "/data",
+							"healing":      false,
+							"local":        true,
+							"path":         "/data",
+							"runtimeState": "online",
+							"state":        "ok",
+							"totalspace":   63728975872,
+							"usedspace":    4699373568,
+							"uuid":         "14b20c88-71bd-4d67-aaf3-bf2446b1b153",
+							"utilization":  7.373998253853503,
+						},
+					},
+					"endpoint":  ":::9000",
+					"max_procs": 6,
+					"mem_stats": map[string]interface{}{
+						"alloc":       180760576,
+						"frees":       0,
+						"heap_alloc":  180760576,
+						"mallocs":     0,
+						"total_alloc": 841904128,
+					},
+					"num_cpu": 6,
+					"state":   "online",
+					"uptime":  18986,
+					"version": "2026-09-01T17:35:49Z@1.0.0-rc.5",
+				},
+			},
+			"usage": map[string]interface{}{
+				"error": nil,
+				"size":  0,
+			},
+			"versions": map[string]interface{}{
+				"count": 0,
+				"error": nil,
+			},
+		},
+	}
+}

--- a/provider/provider.go
+++ b/provider/provider.go
@@ -148,6 +148,7 @@ func (p *RustfsProvider) DataSources(ctx context.Context) []func() datasource.Da
 		NewUsersDataSource,
 		NewIAMPoliciesDataSource,
 		NewIAMPolicyDataSource,
+		NewServerInfoDataSource,
 	}
 }
 

--- a/provider/rustfs_server_info_data_source.go
+++ b/provider/rustfs_server_info_data_source.go
@@ -1,0 +1,487 @@
+package provider
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"sort"
+	"strconv"
+
+	"github.com/hashicorp/terraform-plugin-framework/attr"
+	"github.com/hashicorp/terraform-plugin-framework/datasource"
+	"github.com/hashicorp/terraform-plugin-framework/datasource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/weinmann-emt/terraform-provider-rustfs/pkg/rustfs"
+)
+
+var _ datasource.DataSource = &ServerInfoDataSource{}
+
+type ServerInfoDataSource struct {
+	client *AllClient
+}
+
+type ServerInfoDataSourceModel struct {
+	Mode              types.String `tfsdk:"mode"`
+	DeploymentID      types.String `tfsdk:"deployment_id"`
+	Region            types.String `tfsdk:"region"`
+	BitrotSelftest    types.String `tfsdk:"bitrot_selftest"`
+	BackendType       types.String `tfsdk:"backend_type"`
+	OfflineDisks      types.Int64  `tfsdk:"offline_disks"`
+	OnlineDisks       types.Int64  `tfsdk:"online_disks"`
+	TotalDrivesPerSet types.List   `tfsdk:"total_drives_per_set"`
+	TotalSets         types.List   `tfsdk:"total_sets"`
+	BucketCount       types.Int64  `tfsdk:"bucket_count"`
+	ObjectCount       types.Int64  `tfsdk:"object_count"`
+	VersionCount      types.Int64  `tfsdk:"version_count"`
+	DeleteMarkerCount types.Int64  `tfsdk:"delete_marker_count"`
+	UsageSize         types.Int64  `tfsdk:"usage_size"`
+	PoolCount         types.Int64  `tfsdk:"pool_count"`
+	Pools             types.List   `tfsdk:"pools"`
+	Servers           types.List   `tfsdk:"servers"`
+	RawJSON           types.String `tfsdk:"raw_json"`
+}
+
+type serverInfoPoolModel struct {
+	PoolNumber         types.Int64 `tfsdk:"pool_number"`
+	SetNumber          types.Int64 `tfsdk:"set_number"`
+	ID                 types.Int64 `tfsdk:"id"`
+	RawCapacity        types.Int64 `tfsdk:"raw_capacity"`
+	RawUsage           types.Int64 `tfsdk:"raw_usage"`
+	Usage              types.Int64 `tfsdk:"usage"`
+	ObjectsCount       types.Int64 `tfsdk:"objects_count"`
+	VersionsCount      types.Int64 `tfsdk:"versions_count"`
+	DeleteMarkersCount types.Int64 `tfsdk:"delete_markers_count"`
+	HealDisks          types.Int64 `tfsdk:"heal_disks"`
+}
+
+type serverInfoDriveModel struct {
+	Endpoint     types.String  `tfsdk:"endpoint"`
+	Path         types.String  `tfsdk:"path"`
+	State        types.String  `tfsdk:"state"`
+	RuntimeState types.String  `tfsdk:"runtime_state"`
+	Healing      types.Bool    `tfsdk:"healing"`
+	Local        types.Bool    `tfsdk:"local"`
+	UUID         types.String  `tfsdk:"uuid"`
+	Totalspace   types.Int64   `tfsdk:"totalspace"`
+	Usedspace    types.Int64   `tfsdk:"usedspace"`
+	Availspace   types.Int64   `tfsdk:"availspace"`
+	Utilization  types.Float64 `tfsdk:"utilization"`
+}
+
+type serverInfoServerModel struct {
+	Endpoint      types.String           `tfsdk:"endpoint"`
+	State         types.String           `tfsdk:"state"`
+	Version       types.String           `tfsdk:"version"`
+	Uptime        types.Int64            `tfsdk:"uptime"`
+	NumCPU        types.Int64            `tfsdk:"num_cpu"`
+	MaxProcs      types.Int64            `tfsdk:"max_procs"`
+	MemAlloc      types.Int64            `tfsdk:"mem_alloc"`
+	MemTotalAlloc types.Int64            `tfsdk:"mem_total_alloc"`
+	Drives        []serverInfoDriveModel `tfsdk:"drives"`
+}
+
+func NewServerInfoDataSource() datasource.DataSource {
+	return &ServerInfoDataSource{}
+}
+
+func (d *ServerInfoDataSource) Metadata(_ context.Context, req datasource.MetadataRequest, resp *datasource.MetadataResponse) {
+	resp.TypeName = req.ProviderTypeName + "_server_info"
+}
+
+func (d *ServerInfoDataSource) Schema(_ context.Context, _ datasource.SchemaRequest, resp *datasource.SchemaResponse) {
+	resp.Schema = schema.Schema{
+		Description:         "Server info for RustFS cluster",
+		MarkdownDescription: "Exposes cluster, server, pool and drive information from the RustFS admin API.",
+		Attributes: map[string]schema.Attribute{
+			"mode": schema.StringAttribute{
+				Computed:    true,
+				Description: "Cluster mode (e.g. online, offline).",
+			},
+			"deployment_id": schema.StringAttribute{
+				Computed:    true,
+				Description: "Cluster deployment ID.",
+			},
+			"region": schema.StringAttribute{
+				Computed:    true,
+				Description: "Cluster region, when configured.",
+			},
+			"bitrot_selftest": schema.StringAttribute{
+				Computed:    true,
+				Description: "Bitrot self test status.",
+			},
+			"backend_type": schema.StringAttribute{
+				Computed:    true,
+				Description: "Backend type (e.g. Erasure).",
+			},
+			"offline_disks": schema.Int64Attribute{
+				Computed:    true,
+				Description: "Number of offline disks.",
+			},
+			"online_disks": schema.Int64Attribute{
+				Computed:    true,
+				Description: "Number of online disks.",
+			},
+			"total_drives_per_set": schema.ListAttribute{
+				Computed:    true,
+				ElementType: types.Int64Type,
+				Description: "Total drives per erasure set.",
+			},
+			"total_sets": schema.ListAttribute{
+				Computed:    true,
+				ElementType: types.Int64Type,
+				Description: "Total number of erasure sets per pool.",
+			},
+			"bucket_count": schema.Int64Attribute{
+				Computed:    true,
+				Description: "Number of buckets in the cluster.",
+			},
+			"object_count": schema.Int64Attribute{
+				Computed:    true,
+				Description: "Number of objects in the cluster.",
+			},
+			"version_count": schema.Int64Attribute{
+				Computed:    true,
+				Description: "Number of object versions in the cluster.",
+			},
+			"delete_marker_count": schema.Int64Attribute{
+				Computed:    true,
+				Description: "Number of delete markers in the cluster.",
+			},
+			"usage_size": schema.Int64Attribute{
+				Computed:    true,
+				Description: "Aggregate usage size in bytes.",
+			},
+			"pool_count": schema.Int64Attribute{
+				Computed:    true,
+				Description: "Number of storage pools in the cluster.",
+			},
+			"pools": schema.ListNestedAttribute{
+				Computed: true,
+				NestedObject: schema.NestedAttributeObject{
+					Attributes: map[string]schema.Attribute{
+						"pool_number": schema.Int64Attribute{
+							Computed: true,
+						},
+						"set_number": schema.Int64Attribute{
+							Computed: true,
+						},
+						"id": schema.Int64Attribute{
+							Computed: true,
+						},
+						"raw_capacity": schema.Int64Attribute{
+							Computed: true,
+						},
+						"raw_usage": schema.Int64Attribute{
+							Computed: true,
+						},
+						"usage": schema.Int64Attribute{
+							Computed: true,
+						},
+						"objects_count": schema.Int64Attribute{
+							Computed: true,
+						},
+						"versions_count": schema.Int64Attribute{
+							Computed: true,
+						},
+						"delete_markers_count": schema.Int64Attribute{
+							Computed: true,
+						},
+						"heal_disks": schema.Int64Attribute{
+							Computed: true,
+						},
+					},
+				},
+				Description: "Storage pools and their erasure sets.",
+			},
+			"servers": schema.ListNestedAttribute{
+				Computed: true,
+				NestedObject: schema.NestedAttributeObject{
+					Attributes: map[string]schema.Attribute{
+						"endpoint": schema.StringAttribute{
+							Computed: true,
+						},
+						"state": schema.StringAttribute{
+							Computed: true,
+						},
+						"version": schema.StringAttribute{
+							Computed: true,
+						},
+						"uptime": schema.Int64Attribute{
+							Computed: true,
+						},
+						"num_cpu": schema.Int64Attribute{
+							Computed: true,
+						},
+						"max_procs": schema.Int64Attribute{
+							Computed: true,
+						},
+						"mem_alloc": schema.Int64Attribute{
+							Computed: true,
+						},
+						"mem_total_alloc": schema.Int64Attribute{
+							Computed: true,
+						},
+						"drives": schema.ListNestedAttribute{
+							Computed: true,
+							NestedObject: schema.NestedAttributeObject{
+								Attributes: map[string]schema.Attribute{
+									"endpoint": schema.StringAttribute{
+										Computed: true,
+									},
+									"path": schema.StringAttribute{
+										Computed: true,
+									},
+									"state": schema.StringAttribute{
+										Computed: true,
+									},
+									"runtime_state": schema.StringAttribute{
+										Computed: true,
+									},
+									"healing": schema.BoolAttribute{
+										Computed: true,
+									},
+									"local": schema.BoolAttribute{
+										Computed: true,
+									},
+									"uuid": schema.StringAttribute{
+										Computed: true,
+									},
+									"totalspace": schema.Int64Attribute{
+										Computed: true,
+									},
+									"usedspace": schema.Int64Attribute{
+										Computed: true,
+									},
+									"availspace": schema.Int64Attribute{
+										Computed: true,
+									},
+									"utilization": schema.Float64Attribute{
+										Computed: true,
+									},
+								},
+							},
+							Description: "Drives attached to this server.",
+						},
+					},
+				},
+				Description: "Server nodes in the cluster.",
+			},
+			"raw_json": schema.StringAttribute{
+				Computed:            true,
+				Description:         "Full raw JSON response from the /info endpoint.",
+				MarkdownDescription: "Full raw JSON response from the /info endpoint.",
+			},
+		},
+	}
+}
+
+func (d *ServerInfoDataSource) Configure(_ context.Context, req datasource.ConfigureRequest, resp *datasource.ConfigureResponse) {
+	if req.ProviderData == nil {
+		return
+	}
+	client, ok := req.ProviderData.(*AllClient)
+	if !ok {
+		resp.Diagnostics.AddError(
+			"Unexpected Data Source Configure Type",
+			fmt.Sprintf("Expected *AllClient, got: %T. Please report this issue to the provider developers.", req.ProviderData),
+		)
+		return
+	}
+	d.client = client
+}
+
+func (d *ServerInfoDataSource) Read(ctx context.Context, _ datasource.ReadRequest, resp *datasource.ReadResponse) {
+	info, err := d.client.RustClient.ServerInfo()
+	if err != nil {
+		resp.Diagnostics.AddError(
+			"Error reading server info",
+			"Could not read server info, unexpected error: "+err.Error(),
+		)
+		return
+	}
+
+	state := ServerInfoDataSourceModel{
+		Mode:              types.StringValue(info.Info.Mode),
+		DeploymentID:      types.StringValue(info.Info.DeploymentID),
+		Region:            optionalString(info.Info.Region),
+		BitrotSelftest:    types.StringValue(info.BitrotSelftest),
+		BackendType:       types.StringValue(info.Info.Backend.BackendType),
+		OfflineDisks:      types.Int64Value(info.Info.Backend.OfflineDisks),
+		OnlineDisks:       types.Int64Value(info.Info.Backend.OnlineDisks),
+		BucketCount:       types.Int64Value(info.Info.Buckets.Count),
+		ObjectCount:       types.Int64Value(info.Info.Objects.Count),
+		VersionCount:      types.Int64Value(info.Info.Versions.Count),
+		DeleteMarkerCount: types.Int64Value(info.Info.Deletemarkers.Count),
+		UsageSize:         types.Int64Value(info.Info.Usage.Size),
+	}
+
+	drivesPerSet, diags := types.ListValueFrom(ctx, types.Int64Type, info.Info.Backend.TotalDrivesPerSet)
+	resp.Diagnostics.Append(diags...)
+	totalSets, diags := types.ListValueFrom(ctx, types.Int64Type, info.Info.Backend.TotalSets)
+	resp.Diagnostics.Append(diags...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+	state.TotalDrivesPerSet = drivesPerSet
+	state.TotalSets = totalSets
+
+	poolModels := flattenPools(info.Info.Pools)
+	state.PoolCount = types.Int64Value(int64(len(poolModels)))
+	pools, diags := types.ListValueFrom(ctx, types.ObjectType{
+		AttrTypes: poolObjectType(),
+	}, poolModels)
+	resp.Diagnostics.Append(diags...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+	state.Pools = pools
+
+	serverModels := flattenServers(info.Info.Servers)
+	servers, diags := types.ListValueFrom(ctx, types.ObjectType{
+		AttrTypes: serverObjectType(),
+	}, serverModels)
+	resp.Diagnostics.Append(diags...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+	state.Servers = servers
+
+	raw, err := json.Marshal(info)
+	if err != nil {
+		resp.Diagnostics.AddError(
+			"Error marshalling server info",
+			"Could not marshal server info: "+err.Error(),
+		)
+		return
+	}
+	state.RawJSON = types.StringValue(string(raw))
+
+	resp.Diagnostics.Append(resp.State.Set(ctx, &state)...)
+}
+
+func optionalString(v *string) types.String {
+	if v == nil {
+		return types.StringNull()
+	}
+	return types.StringValue(*v)
+}
+
+func poolObjectType() map[string]attr.Type {
+	return map[string]attr.Type{
+		"pool_number":          types.Int64Type,
+		"set_number":           types.Int64Type,
+		"id":                   types.Int64Type,
+		"raw_capacity":         types.Int64Type,
+		"raw_usage":            types.Int64Type,
+		"usage":                types.Int64Type,
+		"objects_count":        types.Int64Type,
+		"versions_count":       types.Int64Type,
+		"delete_markers_count": types.Int64Type,
+		"heal_disks":           types.Int64Type,
+	}
+}
+
+func serverObjectType() map[string]attr.Type {
+	return map[string]attr.Type{
+		"endpoint":        types.StringType,
+		"state":           types.StringType,
+		"version":         types.StringType,
+		"uptime":          types.Int64Type,
+		"num_cpu":         types.Int64Type,
+		"max_procs":       types.Int64Type,
+		"mem_alloc":       types.Int64Type,
+		"mem_total_alloc": types.Int64Type,
+		"drives":          types.ListType{ElemType: types.ObjectType{AttrTypes: driveObjectType()}},
+	}
+}
+
+func driveObjectType() map[string]attr.Type {
+	return map[string]attr.Type{
+		"endpoint":      types.StringType,
+		"path":          types.StringType,
+		"state":         types.StringType,
+		"runtime_state": types.StringType,
+		"healing":       types.BoolType,
+		"local":         types.BoolType,
+		"uuid":          types.StringType,
+		"totalspace":    types.Int64Type,
+		"usedspace":     types.Int64Type,
+		"availspace":    types.Int64Type,
+		"utilization":   types.Float64Type,
+	}
+}
+
+func flattenPools(pools map[string]map[string]rustfs.PoolSetInfo) []serverInfoPoolModel {
+	var out []serverInfoPoolModel
+	var poolNumbers []int
+	for poolNumber := range pools {
+		n, err := strconv.Atoi(poolNumber)
+		if err != nil {
+			continue
+		}
+		poolNumbers = append(poolNumbers, n)
+	}
+	sort.Ints(poolNumbers)
+	for _, poolNumber := range poolNumbers {
+		sets := pools[strconv.Itoa(poolNumber)]
+		var setNumbers []int
+		for setNumber := range sets {
+			n, err := strconv.Atoi(setNumber)
+			if err != nil {
+				continue
+			}
+			setNumbers = append(setNumbers, n)
+		}
+		sort.Ints(setNumbers)
+		for _, setNumber := range setNumbers {
+			p := sets[strconv.Itoa(setNumber)]
+			out = append(out, serverInfoPoolModel{
+				PoolNumber:         types.Int64Value(int64(poolNumber)),
+				SetNumber:          types.Int64Value(int64(setNumber)),
+				ID:                 types.Int64Value(p.ID),
+				RawCapacity:        types.Int64Value(p.RawCapacity),
+				RawUsage:           types.Int64Value(p.RawUsage),
+				Usage:              types.Int64Value(p.Usage),
+				ObjectsCount:       types.Int64Value(p.ObjectsCount),
+				VersionsCount:      types.Int64Value(p.VersionsCount),
+				DeleteMarkersCount: types.Int64Value(p.DeleteMarkersCount),
+				HealDisks:          types.Int64Value(p.HealDisks),
+			})
+		}
+	}
+	return out
+}
+
+func flattenServers(servers []rustfs.ServerEntry) []serverInfoServerModel {
+	out := make([]serverInfoServerModel, 0, len(servers))
+	for _, s := range servers {
+		drives := make([]serverInfoDriveModel, 0, len(s.Drives))
+		for _, dr := range s.Drives {
+			drives = append(drives, serverInfoDriveModel{
+				Endpoint:     types.StringValue(dr.Endpoint),
+				Path:         types.StringValue(dr.Path),
+				State:        types.StringValue(dr.State),
+				RuntimeState: types.StringValue(dr.RuntimeState),
+				Healing:      types.BoolValue(dr.Healing),
+				Local:        types.BoolValue(dr.Local),
+				UUID:         types.StringValue(dr.UUID),
+				Totalspace:   types.Int64Value(dr.Totalspace),
+				Usedspace:    types.Int64Value(dr.Usedspace),
+				Availspace:   types.Int64Value(dr.Availspace),
+				Utilization:  types.Float64Value(dr.Utilization),
+			})
+		}
+		out = append(out, serverInfoServerModel{
+			Endpoint:      types.StringValue(s.Endpoint),
+			State:         types.StringValue(s.State),
+			Version:       types.StringValue(s.Version),
+			Uptime:        types.Int64Value(s.Uptime),
+			NumCPU:        types.Int64Value(int64(s.NumCPU)),
+			MaxProcs:      types.Int64Value(int64(s.MaxProcs)),
+			MemAlloc:      types.Int64Value(int64(s.MemStats.Alloc)),
+			MemTotalAlloc: types.Int64Value(int64(s.MemStats.TotalAlloc)),
+			Drives:        drives,
+		})
+	}
+	return out
+}

--- a/provider/rustfs_server_info_data_source.go
+++ b/provider/rustfs_server_info_data_source.go
@@ -472,13 +472,15 @@ func flattenServers(servers []rustfs.ServerEntry) []serverInfoServerModel {
 			})
 		}
 		out = append(out, serverInfoServerModel{
-			Endpoint:      types.StringValue(s.Endpoint),
-			State:         types.StringValue(s.State),
-			Version:       types.StringValue(s.Version),
-			Uptime:        types.Int64Value(s.Uptime),
-			NumCPU:        types.Int64Value(int64(s.NumCPU)),
-			MaxProcs:      types.Int64Value(int64(s.MaxProcs)),
-			MemAlloc:      types.Int64Value(int64(s.MemStats.Alloc)),
+			Endpoint: types.StringValue(s.Endpoint),
+			State:    types.StringValue(s.State),
+			Version:  types.StringValue(s.Version),
+			Uptime:   types.Int64Value(s.Uptime),
+			NumCPU:   types.Int64Value(int64(s.NumCPU)),
+			MaxProcs: types.Int64Value(int64(s.MaxProcs)),
+			//#nosec G115 — memory stats are byte counts that fit in int64
+			MemAlloc: types.Int64Value(int64(s.MemStats.Alloc)),
+			//#nosec G115 — memory stats are byte counts that fit in int64
 			MemTotalAlloc: types.Int64Value(int64(s.MemStats.TotalAlloc)),
 			Drives:        drives,
 		})

--- a/provider/rustfs_server_info_data_source_test.go
+++ b/provider/rustfs_server_info_data_source_test.go
@@ -1,0 +1,28 @@
+package provider
+
+import (
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+)
+
+func TestAccServerInfoDataSource(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccProviderConfig() + `
+data "rustfs_server_info" "cluster" {}
+`,
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttrSet("data.rustfs_server_info.cluster", "mode"),
+					resource.TestCheckResourceAttrSet("data.rustfs_server_info.cluster", "deployment_id"),
+					resource.TestCheckResourceAttrSet("data.rustfs_server_info.cluster", "backend_type"),
+					resource.TestCheckResourceAttrSet("data.rustfs_server_info.cluster", "servers.#"),
+					resource.TestCheckResourceAttrSet("data.rustfs_server_info.cluster", "raw_json"),
+				),
+			},
+		},
+	})
+}


### PR DESCRIPTION
**Issue:** https://github.com/weinmann-emt/terraform-provider-rustfs/issues/113

Add a `rustfs_server_info` data source exposing cluster/server info.

Closes #113

## Changes
- `pkg/rustfs/info.go`: `ServerInfo()` (`GET /rustfs/admin/v3/info`).
- `provider/rustfs_server_info_datasource.go`, registered in `DataSources()`.
- Unit (httptest) + acceptance tests; docs + example.

## Testing
- `go build`, `go vet`, gofmt clean; golangci-lint no new findings.
- Unit + acceptance tests pass against a live RustFS.
