### PR TITLE
feat: add rustfs_storage_info data source (#114)

### DIFF
--- a/docs/data-sources/storage_info.md
+++ b/docs/data-sources/storage_info.md
@@ -1,0 +1,58 @@
+---
+page_title: "rustfs_storage_info Data Source - rustfs"
+description: |-
+  Storage info for the RustFS cluster
+---
+
+# rustfs_storage_info (Data Source)
+
+Storage layout and health information for the RustFS cluster, including the storage backend and a per-drive breakdown.
+
+## Example Usage
+
+```terraform
+data "rustfs_storage_info" "cluster" {}
+
+output "backend_type" {
+  value = data.rustfs_storage_info.cluster.backend.backend_type
+}
+
+output "disk_count" {
+  value = length(data.rustfs_storage_info.cluster.disks)
+}
+
+output "raw" {
+  value = data.rustfs_storage_info.cluster.raw_json
+}
+```
+
+## Schema
+
+### Read-Only
+
+- `backend` (Object) Storage backend configuration.
+  - `backend_type` (String) Storage backend type (e.g. Erasure).
+  - `drives_per_set` (List of Number) Number of drives per erasure set.
+  - `rrsc_data` (List of Number) Reduced redundancy storage class data drives per set.
+  - `rrsc_parities` (List of Number) Reduced redundancy storage class parity drives per set.
+  - `standard_sc_data` (List of Number) Standard storage class data drives per set.
+  - `standard_sc_parities` (List of Number) Standard storage class parity drives per set.
+  - `total_sets` (List of Number) Total number of erasure sets.
+- `disks` (List of Object) Per-drive storage breakdown.
+  - `avail_space` (Number) Available space in bytes.
+  - `disk_index` (Number) Index of the disk within the set.
+  - `endpoint` (String) Disk endpoint.
+  - `free_inodes` (Number) Free inodes.
+  - `healing` (Boolean) Whether the drive is healing.
+  - `local` (Boolean) Whether the drive is local.
+  - `path` (String) Filesystem path of the drive.
+  - `pool_index` (Number) Pool the drive belongs to.
+  - `runtime_state` (String) Runtime state of the drive.
+  - `scanning` (Boolean) Whether the drive is being scanned.
+  - `set_index` (Number) Erasure set the drive belongs to.
+  - `state` (String) Health state of the drive.
+  - `total_space` (Number) Total space in bytes.
+  - `used_inodes` (Number) Used inodes.
+  - `used_space` (Number) Used space in bytes.
+  - `uuid` (String) Unique identifier of the drive.
+- `raw_json` (String) Raw JSON response from the /storageinfo endpoint for full fidelity.

--- a/examples/data-sources/rustfs_storage_info/data-source.tf
+++ b/examples/data-sources/rustfs_storage_info/data-source.tf
@@ -1,0 +1,24 @@
+terraform {
+  required_providers {
+    rustfs = {
+      source = "weinmann/rustfs"
+    }
+  }
+}
+
+provider "rustfs" {
+  endpoint      = "rustfs:9001"
+  access_key    = "rustfsadmin"
+  access_secret = "rustfsadmin"
+  ssl           = false
+}
+
+data "rustfs_storage_info" "cluster" {}
+
+output "backend_type" {
+  value = data.rustfs_storage_info.cluster.backend.backend_type
+}
+
+output "raw" {
+  value = data.rustfs_storage_info.cluster.raw_json
+}

--- a/pkg/rustfs/storage_info.go
+++ b/pkg/rustfs/storage_info.go
@@ -1,0 +1,87 @@
+package rustfs
+
+import (
+	"context"
+	"encoding/json"
+)
+
+// StorageInfo holds the decoded response from GET /rustfs/admin/v3/storageinfo.
+type StorageInfo struct {
+	// AdminDiscovery lists related admin API endpoints.
+	AdminDiscovery *AdminDiscovery `json:"admin_discovery,omitempty"`
+	// Info contains the storage layout and health breakdown.
+	Info *StorageInfoDetails `json:"info,omitempty"`
+}
+
+// AdminDiscovery lists related admin API endpoints.
+type AdminDiscovery struct {
+	ClusterSnapshot     string `json:"clusterSnapshot,omitempty"`
+	ExtensionsCatalog   string `json:"extensionsCatalog,omitempty"`
+	RuntimeCapabilities string `json:"runtimeCapabilities,omitempty"`
+}
+
+// StorageInfoDetails holds the backend and per-drive breakdown.
+type StorageInfoDetails struct {
+	Backend *BackendInfo `json:"backend,omitempty"`
+	Disks   []DiskInfo   `json:"disks,omitempty"`
+}
+
+// BackendInfo describes the storage backend layout.
+type BackendInfo struct {
+	BackendType        string `json:"BackendType,omitempty"`
+	DrivesPerSet       []int  `json:"DrivesPerSet,omitempty"`
+	OfflineDisks       any    `json:"OfflineDisks,omitempty"`
+	OnlineDisks        any    `json:"OnlineDisks,omitempty"`
+	RRSCData           []int  `json:"RRSCData,omitempty"`
+	RRSCParities       []int  `json:"RRSCParities,omitempty"`
+	RRSCParity         int    `json:"RRSCParity,omitempty"`
+	StandardSCData     []int  `json:"StandardSCData,omitempty"`
+	StandardSCParities []int  `json:"StandardSCParities,omitempty"`
+	StandardSCParity   int    `json:"StandardSCParity,omitempty"`
+	TotalSets          []int  `json:"TotalSets,omitempty"`
+}
+
+// DiskInfo describes a single drive.
+type DiskInfo struct {
+	DiskIndex    int    `json:"disk_index,omitempty"`
+	Endpoint     string `json:"endpoint,omitempty"`
+	AvailSpace   int64  `json:"availspace,omitempty"`
+	FreeInodes   int64  `json:"free_inodes,omitempty"`
+	Healing      bool   `json:"healing,omitempty"`
+	Local        bool   `json:"local,omitempty"`
+	Path         string `json:"path,omitempty"`
+	PoolIndex    int    `json:"pool_index,omitempty"`
+	RootDisk     bool   `json:"rootDisk,omitempty"`
+	RuntimeState string `json:"runtimeState,omitempty"`
+	Scanning     bool   `json:"scanning,omitempty"`
+	SetIndex     int    `json:"set_index,omitempty"`
+	State        string `json:"state,omitempty"`
+	TotalSpace   int64  `json:"totalspace,omitempty"`
+	UsedInodes   int64  `json:"used_inodes,omitempty"`
+	UsedSpace    int64  `json:"usedspace,omitempty"`
+	UUID         string `json:"uuid,omitempty"`
+	Major        int    `json:"major,omitempty"`
+	Minor        int    `json:"minor,omitempty"`
+}
+
+// StorageInfo returns storage layout and health from GET /v3/storageinfo.
+func (c *RustfsAdmin) StorageInfo() (*StorageInfo, error) {
+	reqData := RequestData{
+		Method:  "GET",
+		RelPath: "storageinfo",
+	}
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	resp, err := c.doRequest(ctx, reqData)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+
+	var info StorageInfo
+	err = json.NewDecoder(resp.Body).Decode(&info)
+	if err != nil {
+		return nil, err
+	}
+	return &info, nil
+}

--- a/pkg/rustfs/storage_info_test.go
+++ b/pkg/rustfs/storage_info_test.go
@@ -1,0 +1,139 @@
+package rustfs
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+const sampleStorageInfoPayload = `{
+  "admin_discovery": {
+    "clusterSnapshot": "/rustfs/admin/v4/cluster/snapshot",
+    "extensionsCatalog": "/rustfs/admin/v4/extensions/catalog",
+    "runtimeCapabilities": "/rustfs/admin/v4/runtime/capabilities"
+  },
+  "info": {
+    "backend": {
+      "BackendType": "Erasure",
+      "DrivesPerSet": [1],
+      "OfflineDisks": {},
+      "OnlineDisks": {},
+      "RRSCData": [1],
+      "RRSCParities": [0],
+      "RRSCParity": 0,
+      "StandardSCData": [1],
+      "StandardSCParities": [0],
+      "StandardSCParity": 0,
+      "TotalSets": [1]
+    },
+    "disks": [
+      {
+        "availspace": 59029614592,
+        "disk_index": 0,
+        "endpoint": "/data",
+        "free_inodes": 31125287,
+        "healing": false,
+        "local": true,
+        "major": 253,
+        "minor": 4,
+        "path": "/data",
+        "pool_index": 0,
+        "rootDisk": false,
+        "runtimeState": "online",
+        "scanning": false,
+        "set_index": 0,
+        "state": "ok",
+        "totalspace": 63728975872,
+        "used_inodes": 69321,
+        "usedspace": 4699361280,
+        "uuid": "14b20c88-71bd-4d67-aaf3-bf2446b1b153"
+      }
+    ]
+  }
+}`
+
+func newStorageInfoTestServer(t *testing.T, body string, status int) *RustfsAdmin {
+	t.Helper()
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodGet {
+			t.Errorf("expected GET, got %s", r.Method)
+		}
+		if !strings.Contains(r.URL.Path, "/rustfs/admin/v3/storageinfo") {
+			t.Errorf("unexpected path: %s", r.URL.Path)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(status)
+		if body != "" {
+			_, _ = w.Write([]byte(body))
+		}
+	}))
+	t.Cleanup(srv.Close)
+
+	client := New(&RustfsAdminConfig{
+		Endpoint:  srv.Listener.Addr().String(),
+		AccessKey: "admin",
+	})
+	client.accessSecret = "secret"
+	return &client
+}
+
+func TestStorageInfo(t *testing.T) {
+	client := newStorageInfoTestServer(t, sampleStorageInfoPayload, http.StatusOK)
+
+	info, err := client.StorageInfo()
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if info.Info == nil {
+		t.Fatal("expected info details, got nil")
+	}
+	if info.Info.Backend == nil {
+		t.Fatal("expected backend, got nil")
+	}
+	if info.Info.Backend.BackendType != "Erasure" {
+		t.Errorf("expected BackendType Erasure, got %q", info.Info.Backend.BackendType)
+	}
+	if len(info.Info.Disks) != 1 {
+		t.Fatalf("expected 1 disk, got %d", len(info.Info.Disks))
+	}
+	disk := info.Info.Disks[0]
+	if disk.State != "ok" {
+		t.Errorf("expected disk state ok, got %q", disk.State)
+	}
+	if disk.TotalSpace != 63728975872 {
+		t.Errorf("expected totalspace 63728975872, got %d", disk.TotalSpace)
+	}
+	if disk.UsedSpace != 4699361280 {
+		t.Errorf("expected usedspace 4699361280, got %d", disk.UsedSpace)
+	}
+	if disk.AvailSpace != 59029614592 {
+		t.Errorf("expected availspace 59029614592, got %d", disk.AvailSpace)
+	}
+	if disk.UUID != "14b20c88-71bd-4d67-aaf3-bf2446b1b153" {
+		t.Errorf("unexpected uuid: %q", disk.UUID)
+	}
+}
+
+func TestStorageInfoRejectsNonSuccess(t *testing.T) {
+	client := newStorageInfoTestServer(t, `{"error":"boom"}`, http.StatusInternalServerError)
+
+	_, err := client.StorageInfo()
+	if err == nil {
+		t.Fatal("expected error for non-2xx response, got nil")
+	}
+}
+
+func TestStorageInfoValidJSONRoundTrip(t *testing.T) {
+	var decoded map[string]interface{}
+	if err := json.Unmarshal([]byte(sampleStorageInfoPayload), &decoded); err != nil {
+		t.Fatalf("sample payload is not valid JSON: %v", err)
+	}
+	if _, ok := decoded["info"]; !ok {
+		t.Fatal("sample payload missing info field")
+	}
+	if _, ok := decoded["admin_discovery"]; !ok {
+		t.Fatal("sample payload missing admin_discovery field")
+	}
+}

--- a/provider/provider.go
+++ b/provider/provider.go
@@ -148,6 +148,7 @@ func (p *RustfsProvider) DataSources(ctx context.Context) []func() datasource.Da
 		NewUsersDataSource,
 		NewIAMPoliciesDataSource,
 		NewIAMPolicyDataSource,
+		NewStorageInfoDataSource,
 	}
 }
 

--- a/provider/rustfs_storage_info_data_source.go
+++ b/provider/rustfs_storage_info_data_source.go
@@ -1,0 +1,266 @@
+package provider
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+
+	"github.com/hashicorp/terraform-plugin-framework/attr"
+	"github.com/hashicorp/terraform-plugin-framework/datasource"
+	"github.com/hashicorp/terraform-plugin-framework/datasource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+)
+
+var _ datasource.DataSource = &StorageInfoDataSource{}
+
+var storageBackendAttrTypes = map[string]attr.Type{
+	"backend_type":         types.StringType,
+	"drives_per_set":       types.ListType{ElemType: types.Int64Type},
+	"total_sets":           types.ListType{ElemType: types.Int64Type},
+	"standard_sc_data":     types.ListType{ElemType: types.Int64Type},
+	"standard_sc_parities": types.ListType{ElemType: types.Int64Type},
+	"rrsc_data":            types.ListType{ElemType: types.Int64Type},
+	"rrsc_parities":        types.ListType{ElemType: types.Int64Type},
+}
+
+var storageDiskAttrTypes = map[string]attr.Type{
+	"disk_index":    types.Int64Type,
+	"endpoint":      types.StringType,
+	"avail_space":   types.Int64Type,
+	"free_inodes":   types.Int64Type,
+	"used_inodes":   types.Int64Type,
+	"healing":       types.BoolType,
+	"local":         types.BoolType,
+	"path":          types.StringType,
+	"pool_index":    types.Int64Type,
+	"runtime_state": types.StringType,
+	"scanning":      types.BoolType,
+	"set_index":     types.Int64Type,
+	"state":         types.StringType,
+	"total_space":   types.Int64Type,
+	"used_space":    types.Int64Type,
+	"uuid":          types.StringType,
+}
+
+type StorageInfoDataSource struct {
+	client *AllClient
+}
+
+type StorageInfoDataSourceModel struct {
+	Backend types.Object `tfsdk:"backend"`
+	Disks   types.List   `tfsdk:"disks"`
+	RawJSON types.String `tfsdk:"raw_json"`
+}
+
+type storageDiskModel struct {
+	DiskIndex    types.Int64  `tfsdk:"disk_index"`
+	Endpoint     types.String `tfsdk:"endpoint"`
+	AvailSpace   types.Int64  `tfsdk:"avail_space"`
+	FreeInodes   types.Int64  `tfsdk:"free_inodes"`
+	UsedInodes   types.Int64  `tfsdk:"used_inodes"`
+	Healing      types.Bool   `tfsdk:"healing"`
+	Local        types.Bool   `tfsdk:"local"`
+	Path         types.String `tfsdk:"path"`
+	PoolIndex    types.Int64  `tfsdk:"pool_index"`
+	RuntimeState types.String `tfsdk:"runtime_state"`
+	Scanning     types.Bool   `tfsdk:"scanning"`
+	SetIndex     types.Int64  `tfsdk:"set_index"`
+	State        types.String `tfsdk:"state"`
+	TotalSpace   types.Int64  `tfsdk:"total_space"`
+	UsedSpace    types.Int64  `tfsdk:"used_space"`
+	UUID         types.String `tfsdk:"uuid"`
+}
+
+func NewStorageInfoDataSource() datasource.DataSource {
+	return &StorageInfoDataSource{}
+}
+
+func (d *StorageInfoDataSource) Metadata(_ context.Context, req datasource.MetadataRequest, resp *datasource.MetadataResponse) {
+	resp.TypeName = req.ProviderTypeName + "_storage_info"
+}
+
+func (d *StorageInfoDataSource) Schema(_ context.Context, _ datasource.SchemaRequest, resp *datasource.SchemaResponse) {
+	resp.Schema = schema.Schema{
+		Description:         "Storage info for the RustFS cluster",
+		MarkdownDescription: "Storage layout and health information for the RustFS cluster, including the storage backend and a per-drive breakdown.",
+		Attributes: map[string]schema.Attribute{
+			"backend": schema.SingleNestedAttribute{
+				Computed:    true,
+				Description: "Storage backend configuration.",
+				Attributes: map[string]schema.Attribute{
+					"backend_type": schema.StringAttribute{
+						Computed:    true,
+						Description: "Storage backend type (e.g. Erasure).",
+					},
+					"drives_per_set": schema.ListAttribute{
+						Computed:    true,
+						ElementType: types.Int64Type,
+						Description: "Number of drives per erasure set.",
+					},
+					"total_sets": schema.ListAttribute{
+						Computed:    true,
+						ElementType: types.Int64Type,
+						Description: "Total number of erasure sets.",
+					},
+					"standard_sc_data": schema.ListAttribute{
+						Computed:    true,
+						ElementType: types.Int64Type,
+						Description: "Standard storage class data drives per set.",
+					},
+					"standard_sc_parities": schema.ListAttribute{
+						Computed:    true,
+						ElementType: types.Int64Type,
+						Description: "Standard storage class parity drives per set.",
+					},
+					"rrsc_data": schema.ListAttribute{
+						Computed:    true,
+						ElementType: types.Int64Type,
+						Description: "Reduced redundancy storage class data drives per set.",
+					},
+					"rrsc_parities": schema.ListAttribute{
+						Computed:    true,
+						ElementType: types.Int64Type,
+						Description: "Reduced redundancy storage class parity drives per set.",
+					},
+				},
+			},
+			"disks": schema.ListNestedAttribute{
+				Computed:    true,
+				Description: "Per-drive storage breakdown.",
+				NestedObject: schema.NestedAttributeObject{
+					Attributes: map[string]schema.Attribute{
+						"disk_index":    schema.Int64Attribute{Computed: true, Description: "Index of the disk within the set."},
+						"endpoint":      schema.StringAttribute{Computed: true, Description: "Disk endpoint."},
+						"avail_space":   schema.Int64Attribute{Computed: true, Description: "Available space in bytes."},
+						"free_inodes":   schema.Int64Attribute{Computed: true, Description: "Free inodes."},
+						"used_inodes":   schema.Int64Attribute{Computed: true, Description: "Used inodes."},
+						"healing":       schema.BoolAttribute{Computed: true, Description: "Whether the drive is healing."},
+						"local":         schema.BoolAttribute{Computed: true, Description: "Whether the drive is local."},
+						"path":          schema.StringAttribute{Computed: true, Description: "Filesystem path of the drive."},
+						"pool_index":    schema.Int64Attribute{Computed: true, Description: "Pool the drive belongs to."},
+						"runtime_state": schema.StringAttribute{Computed: true, Description: "Runtime state of the drive."},
+						"scanning":      schema.BoolAttribute{Computed: true, Description: "Whether the drive is being scanned."},
+						"set_index":     schema.Int64Attribute{Computed: true, Description: "Erasure set the drive belongs to."},
+						"state":         schema.StringAttribute{Computed: true, Description: "Health state of the drive."},
+						"total_space":   schema.Int64Attribute{Computed: true, Description: "Total space in bytes."},
+						"used_space":    schema.Int64Attribute{Computed: true, Description: "Used space in bytes."},
+						"uuid":          schema.StringAttribute{Computed: true, Description: "Unique identifier of the drive."},
+					},
+				},
+			},
+			"raw_json": schema.StringAttribute{
+				Computed:    true,
+				Description: "Raw JSON response from the /storageinfo endpoint for full fidelity.",
+			},
+		},
+	}
+}
+
+func (d *StorageInfoDataSource) Configure(_ context.Context, req datasource.ConfigureRequest, resp *datasource.ConfigureResponse) {
+	if req.ProviderData == nil {
+		return
+	}
+	client, ok := req.ProviderData.(*AllClient)
+	if !ok {
+		resp.Diagnostics.AddError(
+			"Unexpected Data Source Configure Type",
+			fmt.Sprintf("Expected *AllClient, got: %T. Please report this issue to the provider developers.", req.ProviderData),
+		)
+		return
+	}
+	d.client = client
+}
+
+func (d *StorageInfoDataSource) Read(ctx context.Context, _ datasource.ReadRequest, resp *datasource.ReadResponse) {
+	info, err := d.client.RustClient.StorageInfo()
+	if err != nil {
+		resp.Diagnostics.AddError(
+			"Error reading storage info",
+			"Could not read storage info, unexpected error: "+err.Error(),
+		)
+		return
+	}
+	if info.Info == nil {
+		resp.Diagnostics.AddError(
+			"Error reading storage info",
+			"Response from storageinfo endpoint was missing the 'info' field.",
+		)
+		return
+	}
+
+	raw, err := json.Marshal(info)
+	if err != nil {
+		resp.Diagnostics.AddError(
+			"Error marshalling storage info",
+			"Could not marshal storage info: "+err.Error(),
+		)
+		return
+	}
+
+	state := StorageInfoDataSourceModel{
+		RawJSON: types.StringValue(string(raw)),
+	}
+
+	if info.Info.Backend != nil {
+		drivesPerSet, diags := types.ListValueFrom(ctx, types.Int64Type, info.Info.Backend.DrivesPerSet)
+		resp.Diagnostics.Append(diags...)
+		totalSets, diags := types.ListValueFrom(ctx, types.Int64Type, info.Info.Backend.TotalSets)
+		resp.Diagnostics.Append(diags...)
+		standardSCData, diags := types.ListValueFrom(ctx, types.Int64Type, info.Info.Backend.StandardSCData)
+		resp.Diagnostics.Append(diags...)
+		standardSCParities, diags := types.ListValueFrom(ctx, types.Int64Type, info.Info.Backend.StandardSCParities)
+		resp.Diagnostics.Append(diags...)
+		rrscData, diags := types.ListValueFrom(ctx, types.Int64Type, info.Info.Backend.RRSCData)
+		resp.Diagnostics.Append(diags...)
+		rrscParities, diags := types.ListValueFrom(ctx, types.Int64Type, info.Info.Backend.RRSCParities)
+		resp.Diagnostics.Append(diags...)
+		if resp.Diagnostics.HasError() {
+			return
+		}
+
+		backendObj, diags := types.ObjectValue(storageBackendAttrTypes, map[string]attr.Value{
+			"backend_type":         types.StringValue(info.Info.Backend.BackendType),
+			"drives_per_set":       drivesPerSet,
+			"total_sets":           totalSets,
+			"standard_sc_data":     standardSCData,
+			"standard_sc_parities": standardSCParities,
+			"rrsc_data":            rrscData,
+			"rrsc_parities":        rrscParities,
+		})
+		resp.Diagnostics.Append(diags...)
+		if resp.Diagnostics.HasError() {
+			return
+		}
+		state.Backend = backendObj
+	}
+
+	disks := make([]storageDiskModel, 0, len(info.Info.Disks))
+	for _, disk := range info.Info.Disks {
+		disks = append(disks, storageDiskModel{
+			DiskIndex:    types.Int64Value(int64(disk.DiskIndex)),
+			Endpoint:     types.StringValue(disk.Endpoint),
+			AvailSpace:   types.Int64Value(disk.AvailSpace),
+			FreeInodes:   types.Int64Value(disk.FreeInodes),
+			UsedInodes:   types.Int64Value(disk.UsedInodes),
+			Healing:      types.BoolValue(disk.Healing),
+			Local:        types.BoolValue(disk.Local),
+			Path:         types.StringValue(disk.Path),
+			PoolIndex:    types.Int64Value(int64(disk.PoolIndex)),
+			RuntimeState: types.StringValue(disk.RuntimeState),
+			Scanning:     types.BoolValue(disk.Scanning),
+			SetIndex:     types.Int64Value(int64(disk.SetIndex)),
+			State:        types.StringValue(disk.State),
+			TotalSpace:   types.Int64Value(disk.TotalSpace),
+			UsedSpace:    types.Int64Value(disk.UsedSpace),
+			UUID:         types.StringValue(disk.UUID),
+		})
+	}
+	diskList, diags := types.ListValueFrom(ctx, types.ObjectType{AttrTypes: storageDiskAttrTypes}, disks)
+	resp.Diagnostics.Append(diags...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+	state.Disks = diskList
+
+	resp.Diagnostics.Append(resp.State.Set(ctx, &state)...)
+}

--- a/provider/rustfs_storage_info_data_source_test.go
+++ b/provider/rustfs_storage_info_data_source_test.go
@@ -1,0 +1,52 @@
+package provider
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+)
+
+func TestAccStorageInfo(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccProviderConfig() + `
+data "rustfs_storage_info" "test" {}
+`,
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttrSet("data.rustfs_storage_info.test", "raw_json"),
+					resource.TestCheckResourceAttrSet("data.rustfs_storage_info.test", "backend.backend_type"),
+					resource.TestCheckResourceAttrSet("data.rustfs_storage_info.test", "disks.#"),
+					resource.TestCheckResourceAttrSet("data.rustfs_storage_info.test", "disks.0.path"),
+					resource.TestCheckResourceAttrSet("data.rustfs_storage_info.test", "disks.0.total_space"),
+					resource.TestCheckResourceAttrSet("data.rustfs_storage_info.test", "disks.0.state"),
+				),
+			},
+			{
+				Config: testAccProviderConfig() + `
+data "rustfs_storage_info" "test" {}
+
+output "storage_raw" {
+  value = data.rustfs_storage_info.test.raw_json
+}
+`,
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttrSet("data.rustfs_storage_info.test", "raw_json"),
+					resource.TestCheckResourceAttrWith("data.rustfs_storage_info.test", "raw_json", func(v string) error {
+						var parsed map[string]interface{}
+						if err := json.Unmarshal([]byte(v), &parsed); err != nil {
+							return err
+						}
+						if _, ok := parsed["info"]; !ok {
+							t.Errorf("raw_json missing info field")
+						}
+						return nil
+					}),
+				),
+			},
+		},
+	})
+}


### PR DESCRIPTION
**Issue:** https://github.com/weinmann-emt/terraform-provider-rustfs/issues/114

Add a `rustfs_storage_info` data source exposing storage details.

Closes #114

## Changes
- `pkg/rustfs/storage_info.go`: `StorageInfo()` (`GET /rustfs/admin/v3/storageinfo`).
- `provider/rustfs_storage_info_datasource.go`, registered in `DataSources()`.
- Unit (httptest) + acceptance tests; docs + example.

## Testing
- `go build`, `go vet`, gofmt clean; golangci-lint no new findings.
- Unit + acceptance tests pass against a live RustFS.

## Note
Verified shape is a `{admin_discovery, info:{backend, disks}}` envelope (not a flat map) — schema adapted accordingly, with a `raw_json` attribute for full fidelity.
