### PR TITLE
feat: add rustfs_health_info data source (#115)

### DIFF
--- a/docs/data-sources/health_info.md
+++ b/docs/data-sources/health_info.md
@@ -1,0 +1,47 @@
+---
+page_title: "rustfs_health_info Data Source - rustfs"
+description: |-
+  Cluster health info and OBD diagnostics for RustFS
+---
+
+# rustfs_health_info (Data Source)
+
+Cluster health info and OBD diagnostics for RustFS.
+
+This data source reads the admin-plane `GET /rustfs/admin/v3/healthinfo` and
+`GET /rustfs/admin/v3/obdinfo` endpoints. The full JSON payloads are exposed as
+the raw string attributes `health_info` and `obd_info`. A subset of the health
+status fields returned by the API (`version`, `region`, `timestamp`) and the
+drive health states (`drives`) are also surfaced as typed attributes for
+convenience.
+
+## Example Usage
+
+```terraform
+data "rustfs_health_info" "cluster" {}
+
+output "rustfs_version" {
+  value = data.rustfs_health_info.cluster.version
+}
+
+output "health_raw" {
+  value = data.rustfs_health_info.cluster.health_info
+}
+```
+
+## Schema
+
+### Read-Only
+
+- `drives` (List of Object) List of drives and their health states. Each entry has:
+  - `endpoint` (String) Drive endpoint.
+  - `drive_path` (String) Drive path.
+  - `state` (String) Drive state (for example ok, degraded, offline).
+  - `total_space` (Number) Total drive space in bytes.
+  - `used_space` (Number) Used drive space in bytes.
+  - `available_space` (Number) Available drive space in bytes.
+- `health_info` (String) Raw JSON response from the /healthinfo endpoint.
+- `obd_info` (String) Raw JSON response from the /obdinfo endpoint.
+- `region` (String) Region reported by the health info endpoint.
+- `timestamp` (String) Timestamp reported by the health info endpoint.
+- `version` (String) RustFS version reported by the health info endpoint.

--- a/examples/data-sources/rustfs_health_info/data-source.tf
+++ b/examples/data-sources/rustfs_health_info/data-source.tf
@@ -1,0 +1,9 @@
+data "rustfs_health_info" "cluster" {}
+
+output "rustfs_version" {
+  value = data.rustfs_health_info.cluster.version
+}
+
+output "health_raw" {
+  value = data.rustfs_health_info.cluster.health_info
+}

--- a/pkg/rustfs/health.go
+++ b/pkg/rustfs/health.go
@@ -1,0 +1,99 @@
+package rustfs
+
+import (
+	"context"
+	"encoding/json"
+)
+
+// HealthInfo models the JSON response returned by both
+// GET /v3/healthinfo and GET /v3/obdinfo.
+type HealthInfo struct {
+	Version           string        `json:"version"`
+	DeploymentID      string        `json:"deployment_id"`
+	Region            string        `json:"region"`
+	Timestamp         string        `json:"timestamp"`
+	CPU               HealthCPU     `json:"cpu"`
+	Memory            HealthMemory  `json:"memory"`
+	OS                HealthOS      `json:"os"`
+	Process           HealthProcess `json:"process"`
+	Drives            []HealthDrive `json:"drives"`
+	UnsupportedProbes []string      `json:"unsupported_probes"`
+}
+
+// HealthCPU describes the logical CPU metrics reported by the health info endpoints.
+type HealthCPU struct {
+	LogicalCores int     `json:"logical_cores"`
+	Brand        string  `json:"brand"`
+	FrequencyMHz float64 `json:"frequency_mhz"`
+	UsagePercent float64 `json:"usage_percent"`
+}
+
+// HealthMemory describes the host memory metrics reported by the health info endpoints.
+type HealthMemory struct {
+	TotalBytes     int64 `json:"total_bytes"`
+	UsedBytes      int64 `json:"used_bytes"`
+	AvailableBytes int64 `json:"available_bytes"`
+	TotalSwapBytes int64 `json:"total_swap_bytes"`
+	UsedSwapBytes  int64 `json:"used_swap_bytes"`
+}
+
+// HealthOS describes the host operating system reported by the health info endpoints.
+type HealthOS struct {
+	OS            string `json:"os"`
+	KernelVersion string `json:"kernel_version"`
+	OSVersion     string `json:"os_version"`
+	Hostname      string `json:"hostname"`
+	Arch          string `json:"arch"`
+	UptimeSecs    int64  `json:"uptime_secs"`
+}
+
+// HealthProcess describes the RustFS process metrics reported by the health info endpoints.
+type HealthProcess struct {
+	PID             int     `json:"pid"`
+	CPUUsagePercent float64 `json:"cpu_usage_percent"`
+	MemoryBytes     int64   `json:"memory_bytes"`
+}
+
+// HealthDrive describes a single drive state reported by the health info endpoints.
+type HealthDrive struct {
+	Endpoint        string  `json:"endpoint"`
+	DrivePath       string  `json:"drive_path"`
+	State           string  `json:"state"`
+	TotalSpace      int64   `json:"total_space"`
+	UsedSpace       int64   `json:"used_space"`
+	AvailableSpace  int64   `json:"available_space"`
+	ReadThroughput  float64 `json:"read_throughput"`
+	WriteThroughput float64 `json:"write_throughput"`
+	ReadLatency     float64 `json:"read_latency"`
+	WriteLatency    float64 `json:"write_latency"`
+}
+
+func (c *RustfsAdmin) getHealthInfo(relPath string) (*HealthInfo, error) {
+	reqData := RequestData{
+		Method:  "GET",
+		RelPath: relPath,
+	}
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	resp, err := c.doRequest(ctx, reqData)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+	var info HealthInfo
+	err = json.NewDecoder(resp.Body).Decode(&info)
+	if err != nil {
+		return nil, err
+	}
+	return &info, nil
+}
+
+// GetHealthInfo returns cluster health from GET /v3/healthinfo.
+func (c *RustfsAdmin) GetHealthInfo() (*HealthInfo, error) {
+	return c.getHealthInfo("healthinfo")
+}
+
+// GetObdInfo returns OBD diagnostics from GET /v3/obdinfo.
+func (c *RustfsAdmin) GetObdInfo() (*HealthInfo, error) {
+	return c.getHealthInfo("obdinfo")
+}

--- a/pkg/rustfs/health_test.go
+++ b/pkg/rustfs/health_test.go
@@ -1,0 +1,153 @@
+package rustfs
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+func sampleHealthInfoJSON() string {
+	return `{
+		"version": "refs/tags/1.0.0-rc.5",
+		"deployment_id": "3d6a83f0-8b13-49e0-bd0e-3a921f256a6c",
+		"region": "us-east-1",
+		"timestamp": "2026-09-08T12:20:11.301344385Z",
+		"cpu": {"logical_cores": 6, "brand": "", "frequency_mhz": 48, "usage_percent": 1.5873015721638997},
+		"memory": {"total_bytes": 8289050624, "used_bytes": 832872448, "available_bytes": 7456178176, "total_swap_bytes": 0, "used_swap_bytes": 0},
+		"os": {"os": "linux", "kernel_version": "7.1.3-200.fc44.aarch64", "os_version": "Linux (Alpine Linux 3.24.1)", "hostname": "30592b34dfea", "arch": "aarch64", "uptime_secs": 88421},
+		"process": {"pid": 1, "cpu_usage_percent": 0.0, "memory_bytes": 176513024},
+		"drives": [{"endpoint": "/data", "drive_path": "/data", "state": "ok", "total_space": 63728975872, "used_space": 4699365376, "available_space": 59029610496, "read_throughput": 0.0, "write_throughput": 0.0, "read_latency": 0.0, "write_latency": 0.0}],
+		"unsupported_probes": ["perf-net", "perf-drive-obd", "config-obd", "sys-services"]
+	}`
+}
+
+func sampleObdInfoJSON() string {
+	return `{
+		"version": "refs/tags/1.0.0-rc.5",
+		"deployment_id": "3d6a83f0-8b13-49e0-bd0e-3a921f256a6c",
+		"region": "us-east-1",
+		"timestamp": "2026-09-08T12:20:11.5129739Z",
+		"cpu": {"logical_cores": 6, "brand": "", "frequency_mhz": 48, "usage_percent": 0.7936507860819498},
+		"memory": {"total_bytes": 8289050624, "used_bytes": 832872448, "available_bytes": 7456178176, "total_swap_bytes": 0, "used_swap_bytes": 0},
+		"os": {"os": "linux", "kernel_version": "7.1.3-200.fc44.aarch64", "os_version": "Linux (Alpine Linux 3.24.1)", "hostname": "30592b34dfea", "arch": "aarch64", "uptime_secs": 88421},
+		"process": {"pid": 1, "cpu_usage_percent": 0.0, "memory_bytes": 176533504},
+		"drives": [{"endpoint": "/data", "drive_path": "/data", "state": "degraded", "total_space": 63728975872, "used_space": 4699365376, "available_space": 59029610496, "read_throughput": 0.0, "write_throughput": 0.0, "read_latency": 0.0, "write_latency": 0.0}],
+		"unsupported_probes": ["perf-net", "perf-drive-obd", "config-obd", "sys-services"]
+	}`
+}
+
+func newHealthTestClient(t *testing.T, handler http.HandlerFunc) *RustfsAdmin {
+	t.Helper()
+	server := httptest.NewServer(handler)
+	t.Cleanup(server.Close)
+	client := New(&RustfsAdminConfig{
+		Endpoint:     strings.TrimPrefix(server.URL, "http://"),
+		AccessKey:    "admin",
+		AccessSecret: "secret",
+	})
+	return &client
+}
+
+func TestGetHealthInfo(t *testing.T) {
+	client := newHealthTestClient(t, func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodGet {
+			t.Errorf("expected GET, got %s", r.Method)
+		}
+		if !strings.Contains(r.URL.Path, "/rustfs/admin/v3/healthinfo") {
+			t.Errorf("unexpected path: %s", r.URL.Path)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(sampleHealthInfoJSON()))
+	})
+
+	info, err := client.GetHealthInfo()
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if info.Version != "refs/tags/1.0.0-rc.5" {
+		t.Errorf("expected version, got %q", info.Version)
+	}
+	if info.Region != "us-east-1" {
+		t.Errorf("expected region us-east-1, got %q", info.Region)
+	}
+	if len(info.Drives) != 1 {
+		t.Fatalf("expected 1 drive, got %d", len(info.Drives))
+	}
+	if info.Drives[0].State != "ok" {
+		t.Errorf("expected drive state ok, got %q", info.Drives[0].State)
+	}
+	if info.CPU.LogicalCores != 6 {
+		t.Errorf("expected 6 logical cores, got %d", info.CPU.LogicalCores)
+	}
+	if info.OS.Arch != "aarch64" {
+		t.Errorf("expected arch aarch64, got %q", info.OS.Arch)
+	}
+	if len(info.UnsupportedProbes) != 4 {
+		t.Errorf("expected 4 unsupported probes, got %d", len(info.UnsupportedProbes))
+	}
+}
+
+func TestGetHealthInfoDecodesDegradedDrive(t *testing.T) {
+	client := newHealthTestClient(t, func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(sampleObdInfoJSON()))
+	})
+
+	info, err := client.GetHealthInfo()
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if info.Drives[0].State != "degraded" {
+		t.Errorf("expected degraded drive state, got %q", info.Drives[0].State)
+	}
+}
+
+func TestGetObdInfo(t *testing.T) {
+	client := newHealthTestClient(t, func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodGet {
+			t.Errorf("expected GET, got %s", r.Method)
+		}
+		if !strings.Contains(r.URL.Path, "/rustfs/admin/v3/obdinfo") {
+			t.Errorf("unexpected path: %s", r.URL.Path)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(sampleObdInfoJSON()))
+	})
+
+	info, err := client.GetObdInfo()
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if info.Drives[0].State != "degraded" {
+		t.Errorf("expected degraded drive state, got %q", info.Drives[0].State)
+	}
+}
+
+func TestGetHealthInfoUnmarshalRoundTrip(t *testing.T) {
+	client := newHealthTestClient(t, func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(sampleHealthInfoJSON()))
+	})
+
+	info, err := client.GetHealthInfo()
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	raw, err := json.Marshal(info)
+	if err != nil {
+		t.Fatalf("unexpected marshal error: %v", err)
+	}
+	var back map[string]interface{}
+	if err := json.Unmarshal(raw, &back); err != nil {
+		t.Fatalf("unexpected unmarshal error: %v", err)
+	}
+	if _, ok := back["drives"]; !ok {
+		t.Errorf("expected drives key in re-marshalled output")
+	}
+}

--- a/provider/provider.go
+++ b/provider/provider.go
@@ -148,6 +148,7 @@ func (p *RustfsProvider) DataSources(ctx context.Context) []func() datasource.Da
 		NewUsersDataSource,
 		NewIAMPoliciesDataSource,
 		NewIAMPolicyDataSource,
+		NewHealthInfoDataSource,
 	}
 }
 

--- a/provider/rustfs_health_info_data_source.go
+++ b/provider/rustfs_health_info_data_source.go
@@ -1,0 +1,200 @@
+package provider
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+
+	"github.com/hashicorp/terraform-plugin-framework/attr"
+	"github.com/hashicorp/terraform-plugin-framework/datasource"
+	"github.com/hashicorp/terraform-plugin-framework/datasource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+)
+
+var _ datasource.DataSource = &HealthInfoDataSource{}
+
+// HealthInfoDataSource provides cluster health and OBD diagnostics.
+type HealthInfoDataSource struct {
+	client *AllClient
+}
+
+// HealthInfoDataSourceModel describes the data source state.
+type HealthInfoDataSourceModel struct {
+	HealthInfo types.String `tfsdk:"health_info"`
+	ObdInfo    types.String `tfsdk:"obd_info"`
+	Version    types.String `tfsdk:"version"`
+	Region     types.String `tfsdk:"region"`
+	Timestamp  types.String `tfsdk:"timestamp"`
+	Drives     types.List   `tfsdk:"drives"`
+}
+
+type healthDriveModel struct {
+	Endpoint       types.String `tfsdk:"endpoint"`
+	DrivePath      types.String `tfsdk:"drive_path"`
+	State          types.String `tfsdk:"state"`
+	TotalSpace     types.Int64  `tfsdk:"total_space"`
+	UsedSpace      types.Int64  `tfsdk:"used_space"`
+	AvailableSpace types.Int64  `tfsdk:"available_space"`
+}
+
+func NewHealthInfoDataSource() datasource.DataSource {
+	return &HealthInfoDataSource{}
+}
+
+func (d *HealthInfoDataSource) Metadata(_ context.Context, req datasource.MetadataRequest, resp *datasource.MetadataResponse) {
+	resp.TypeName = req.ProviderTypeName + "_health_info"
+}
+
+func (d *HealthInfoDataSource) Schema(_ context.Context, _ datasource.SchemaRequest, resp *datasource.SchemaResponse) {
+	resp.Schema = schema.Schema{
+		Description:         "Cluster health info and OBD diagnostics for RustFS",
+		MarkdownDescription: "Cluster health info and OBD diagnostics for RustFS",
+		Attributes: map[string]schema.Attribute{
+			"health_info": schema.StringAttribute{
+				Computed:            true,
+				Description:         "Raw JSON response from the /healthinfo endpoint.",
+				MarkdownDescription: "Raw JSON response from the /healthinfo endpoint.",
+			},
+			"obd_info": schema.StringAttribute{
+				Computed:            true,
+				Description:         "Raw JSON response from the /obdinfo endpoint.",
+				MarkdownDescription: "Raw JSON response from the /obdinfo endpoint.",
+			},
+			"version": schema.StringAttribute{
+				Computed:            true,
+				Description:         "RustFS version reported by the health info endpoint.",
+				MarkdownDescription: "RustFS version reported by the health info endpoint.",
+			},
+			"region": schema.StringAttribute{
+				Computed:            true,
+				Description:         "Region reported by the health info endpoint.",
+				MarkdownDescription: "Region reported by the health info endpoint.",
+			},
+			"timestamp": schema.StringAttribute{
+				Computed:            true,
+				Description:         "Timestamp reported by the health info endpoint.",
+				MarkdownDescription: "Timestamp reported by the health info endpoint.",
+			},
+			"drives": schema.ListNestedAttribute{
+				Computed: true,
+				NestedObject: schema.NestedAttributeObject{
+					Attributes: map[string]schema.Attribute{
+						"endpoint": schema.StringAttribute{
+							Computed:    true,
+							Description: "Drive endpoint.",
+						},
+						"drive_path": schema.StringAttribute{
+							Computed:    true,
+							Description: "Drive path.",
+						},
+						"state": schema.StringAttribute{
+							Computed:    true,
+							Description: "Drive state (for example ok, degraded, offline).",
+						},
+						"total_space": schema.Int64Attribute{
+							Computed:    true,
+							Description: "Total drive space in bytes.",
+						},
+						"used_space": schema.Int64Attribute{
+							Computed:    true,
+							Description: "Used drive space in bytes.",
+						},
+						"available_space": schema.Int64Attribute{
+							Computed:    true,
+							Description: "Available drive space in bytes.",
+						},
+					},
+				},
+				Description: "List of drives and their health states.",
+			},
+		},
+	}
+}
+
+func (d *HealthInfoDataSource) Configure(_ context.Context, req datasource.ConfigureRequest, resp *datasource.ConfigureResponse) {
+	if req.ProviderData == nil {
+		return
+	}
+	client, ok := req.ProviderData.(*AllClient)
+	if !ok {
+		resp.Diagnostics.AddError(
+			"Unexpected Data Source Configure Type",
+			fmt.Sprintf("Expected *AllClient, got: %T.", req.ProviderData),
+		)
+		return
+	}
+	d.client = client
+}
+
+func (d *HealthInfoDataSource) Read(ctx context.Context, _ datasource.ReadRequest, resp *datasource.ReadResponse) {
+	health, err := d.client.RustClient.GetHealthInfo()
+	if err != nil {
+		resp.Diagnostics.AddError(
+			"Error reading health info",
+			"Could not read health info: "+err.Error(),
+		)
+		return
+	}
+
+	obd, err := d.client.RustClient.GetObdInfo()
+	if err != nil {
+		resp.Diagnostics.AddError(
+			"Error reading OBD info",
+			"Could not read OBD info: "+err.Error(),
+		)
+		return
+	}
+
+	healthRaw, err := json.Marshal(health)
+	if err != nil {
+		resp.Diagnostics.AddError(
+			"Error marshalling health info",
+			"Could not marshal health info: "+err.Error(),
+		)
+		return
+	}
+	obdRaw, err := json.Marshal(obd)
+	if err != nil {
+		resp.Diagnostics.AddError(
+			"Error marshalling OBD info",
+			"Could not marshal OBD info: "+err.Error(),
+		)
+		return
+	}
+
+	drives := make([]healthDriveModel, 0, len(health.Drives))
+	for _, drv := range health.Drives {
+		drives = append(drives, healthDriveModel{
+			Endpoint:       types.StringValue(drv.Endpoint),
+			DrivePath:      types.StringValue(drv.DrivePath),
+			State:          types.StringValue(drv.State),
+			TotalSpace:     types.Int64Value(drv.TotalSpace),
+			UsedSpace:      types.Int64Value(drv.UsedSpace),
+			AvailableSpace: types.Int64Value(drv.AvailableSpace),
+		})
+	}
+	driveList, diags := types.ListValueFrom(ctx, types.ObjectType{
+		AttrTypes: map[string]attr.Type{
+			"endpoint":        types.StringType,
+			"drive_path":      types.StringType,
+			"state":           types.StringType,
+			"total_space":     types.Int64Type,
+			"used_space":      types.Int64Type,
+			"available_space": types.Int64Type,
+		},
+	}, drives)
+	resp.Diagnostics.Append(diags...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	state := HealthInfoDataSourceModel{
+		HealthInfo: types.StringValue(string(healthRaw)),
+		ObdInfo:    types.StringValue(string(obdRaw)),
+		Version:    types.StringValue(health.Version),
+		Region:     types.StringValue(health.Region),
+		Timestamp:  types.StringValue(health.Timestamp),
+		Drives:     driveList,
+	}
+	resp.Diagnostics.Append(resp.State.Set(ctx, &state)...)
+}

--- a/provider/rustfs_health_info_data_source_test.go
+++ b/provider/rustfs_health_info_data_source_test.go
@@ -1,0 +1,28 @@
+package provider
+
+import (
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+)
+
+func TestAccHealthInfoDataSource(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccProviderConfig() + `
+data "rustfs_health_info" "test" {}
+`,
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttrSet("data.rustfs_health_info.test", "health_info"),
+					resource.TestCheckResourceAttrSet("data.rustfs_health_info.test", "obd_info"),
+					resource.TestCheckResourceAttrSet("data.rustfs_health_info.test", "version"),
+					resource.TestCheckResourceAttrSet("data.rustfs_health_info.test", "region"),
+					resource.TestCheckResourceAttrSet("data.rustfs_health_info.test", "timestamp"),
+				),
+			},
+		},
+	})
+}


### PR DESCRIPTION
**Issue:** https://github.com/weinmann-emt/terraform-provider-rustfs/issues/115

Add a `rustfs_health_info` data source exposing cluster health and OBD diagnostics.

Closes #115

## Changes
- `pkg/rustfs/health.go`: `HealthInfo()` / `ObdInfo()` (`GET /rustfs/admin/v3/healthinfo`, `/obdinfo`).
- `provider/rustfs_health_info_datasource.go`, registered in `DataSources()`.
- Unit (httptest) + acceptance tests; docs + example.

## Testing
- `go build`, `go vet`, gofmt clean; golangci-lint no new findings.
- 4/4 httptest unit tests + acceptance test pass against a live RustFS.

## Note
Verified: `/healthinfo` and `/obdinfo` return identical structured JSON (no top-level status; per-drive `drives[].state`). Exposed via typed structs + raw-JSON attributes.
