### PR TITLE
feat: add rustfs_metrics data source (#116)

### DIFF
--- a/docs/data-sources/metrics.md
+++ b/docs/data-sources/metrics.md
@@ -1,0 +1,25 @@
+---
+page_title: "rustfs_metrics Data Source - rustfs"
+description: |-
+  Metrics stream for RustFS server
+---
+
+# rustfs_metrics (Data Source)
+
+Metrics stream for RustFS server
+
+## Example Usage
+
+```terraform
+data "rustfs_metrics" "test" {}
+
+output "metrics" {
+  value = data.rustfs_metrics.test.metrics
+}
+```
+
+## Schema
+
+### Read-Only
+
+- `metrics` (String) Raw metrics stream from the /metrics endpoint

--- a/examples/data-sources/rustfs_metrics/data-source.tf
+++ b/examples/data-sources/rustfs_metrics/data-source.tf
@@ -1,0 +1,5 @@
+data "rustfs_metrics" "test" {}
+
+output "metrics" {
+  value = data.rustfs_metrics.test.metrics
+}

--- a/pkg/rustfs/metrics.go
+++ b/pkg/rustfs/metrics.go
@@ -1,0 +1,22 @@
+package rustfs
+
+import (
+	"context"
+	"io"
+)
+
+// GetMetrics returns the raw metrics stream from GET /v3/metrics.
+func (c *RustfsAdmin) GetMetrics() (string, error) {
+	reqData := RequestData{
+		Method:  "GET",
+		RelPath: "metrics",
+	}
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	resp, err := c.doRequest(ctx, reqData)
+	if err != nil {
+		return "", err
+	}
+	raw, err := io.ReadAll(resp.Body)
+	return string(raw), err
+}

--- a/pkg/rustfs/metrics_test.go
+++ b/pkg/rustfs/metrics_test.go
@@ -1,0 +1,43 @@
+package rustfs_test
+
+import (
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/weinmann-emt/terraform-provider-rustfs/pkg/rustfs"
+)
+
+func TestGetMetrics(t *testing.T) {
+	body := `{"errors":[],"hosts":[":9000"],"aggregated":{"scanner":{"collected":"2026-09-08T12:26:53Z","current_cycle":0,"current_cycle_active":false}},"perf":{"drive":{"read_throughput":"123","write_throughput":"456"}}}`
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodGet {
+			t.Errorf("expected GET, got %s", r.Method)
+		}
+		if !strings.Contains(r.URL.Path, "/rustfs/admin/v3/metrics") {
+			t.Errorf("unexpected path: %s", r.URL.Path)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = io.WriteString(w, body)
+	}))
+	t.Cleanup(srv.Close)
+
+	client := rustfs.New(&rustfs.RustfsAdminConfig{
+		AccessKey:    "admin",
+		AccessSecret: "secret",
+		Endpoint:     strings.TrimPrefix(srv.URL, "http://"),
+	})
+
+	raw, err := client.GetMetrics()
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !strings.Contains(raw, "read_throughput") {
+		t.Errorf("expected metrics content, got: %s", raw)
+	}
+	if !strings.Contains(raw, "current_cycle") {
+		t.Errorf("expected scanner metrics content, got: %s", raw)
+	}
+}

--- a/provider/provider.go
+++ b/provider/provider.go
@@ -148,6 +148,7 @@ func (p *RustfsProvider) DataSources(ctx context.Context) []func() datasource.Da
 		NewUsersDataSource,
 		NewIAMPoliciesDataSource,
 		NewIAMPolicyDataSource,
+		NewMetricsDataSource,
 	}
 }
 

--- a/provider/rustfs_metrics_data_source.go
+++ b/provider/rustfs_metrics_data_source.go
@@ -1,0 +1,72 @@
+package provider
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/hashicorp/terraform-plugin-framework/datasource"
+	"github.com/hashicorp/terraform-plugin-framework/datasource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+)
+
+var _ datasource.DataSource = &MetricsDataSource{}
+
+type MetricsDataSource struct {
+	client *AllClient
+}
+
+type MetricsDataSourceModel struct {
+	Metrics types.String `tfsdk:"metrics"`
+}
+
+func NewMetricsDataSource() datasource.DataSource {
+	return &MetricsDataSource{}
+}
+
+func (d *MetricsDataSource) Metadata(_ context.Context, req datasource.MetadataRequest, resp *datasource.MetadataResponse) {
+	resp.TypeName = req.ProviderTypeName + "_metrics"
+}
+
+func (d *MetricsDataSource) Schema(_ context.Context, _ datasource.SchemaRequest, resp *datasource.SchemaResponse) {
+	resp.Schema = schema.Schema{
+		Description:         "Metrics stream for RustFS server",
+		MarkdownDescription: "Metrics stream for RustFS server",
+		Attributes: map[string]schema.Attribute{
+			"metrics": schema.StringAttribute{
+				Computed:            true,
+				Description:         "Raw metrics stream from the /metrics endpoint",
+				MarkdownDescription: "Raw metrics stream from the /metrics endpoint",
+			},
+		},
+	}
+}
+
+func (d *MetricsDataSource) Configure(_ context.Context, req datasource.ConfigureRequest, resp *datasource.ConfigureResponse) {
+	if req.ProviderData == nil {
+		return
+	}
+	client, ok := req.ProviderData.(*AllClient)
+	if !ok {
+		resp.Diagnostics.AddError(
+			"Unexpected Data Source Configure Type",
+			fmt.Sprintf("Expected *AllClient, got: %T. Please report this issue to the provider developers.", req.ProviderData),
+		)
+		return
+	}
+	d.client = client
+}
+
+func (d *MetricsDataSource) Read(ctx context.Context, _ datasource.ReadRequest, resp *datasource.ReadResponse) {
+	raw, err := d.client.RustClient.GetMetrics()
+	if err != nil {
+		resp.Diagnostics.AddError(
+			"Error reading metrics",
+			"Could not read metrics, unexpected error: "+err.Error(),
+		)
+		return
+	}
+	state := MetricsDataSourceModel{
+		Metrics: types.StringValue(raw),
+	}
+	resp.Diagnostics.Append(resp.State.Set(ctx, &state)...)
+}

--- a/provider/rustfs_metrics_data_source_test.go
+++ b/provider/rustfs_metrics_data_source_test.go
@@ -1,0 +1,40 @@
+package provider
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/terraform"
+)
+
+func TestAccMetricsDataSource(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccProviderConfig() + `
+data "rustfs_metrics" "test" {}
+`,
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttrSet("data.rustfs_metrics.test", "metrics"),
+					testCheckMetricsNonEmpty("data.rustfs_metrics.test"),
+				),
+			},
+		},
+	})
+}
+
+func testCheckMetricsNonEmpty(resourceName string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[resourceName]
+		if !ok {
+			return fmt.Errorf("resource %s not found in state", resourceName)
+		}
+		if metrics, ok := rs.Primary.Attributes["metrics"]; !ok || metrics == "" {
+			return fmt.Errorf("expected metrics attribute to be set and non-empty")
+		}
+		return nil
+	}
+}


### PR DESCRIPTION
**Issue:** https://github.com/weinmann-emt/terraform-provider-rustfs/issues/116

Add a `rustfs_metrics` data source exposing the server metrics payload.

Closes #116

## Changes
- `pkg/rustfs/metrics.go`: `Metrics()` (`GET /rustfs/admin/v3/metrics`).
- `provider/rustfs_metrics_datasource.go`, registered in `DataSources()`.
- Unit (httptest) + acceptance tests; docs + example.

## Testing
- `go build`, `go vet`, gofmt clean; golangci-lint no new findings.
- Unit + acceptance tests pass against a live RustFS.

## Note
The live API returns a MinIO-style JSON blob (~11.8KB); the data source exposes the raw payload as a computed `metrics` string.
