### PR TITLE
feat: add rustfs_groups data source (#117)

### DIFF
--- a/docs/data-sources/groups.md
+++ b/docs/data-sources/groups.md
@@ -1,0 +1,25 @@
+---
+page_title: "rustfs_groups Data Source - rustfs"
+description: |-
+  Lists all IAM groups for RustFS
+---
+
+# rustfs_groups (Data Source)
+
+Lists all IAM groups for RustFS.
+
+## Example Usage
+
+```terraform
+data "rustfs_groups" "all" {}
+
+output "group_names" {
+  value = data.rustfs_groups.all.groups
+}
+```
+
+## Schema
+
+### Read-Only
+
+- `groups` (Set of String) Set of IAM group names

--- a/examples/data-sources/rustfs_groups/data-source.tf
+++ b/examples/data-sources/rustfs_groups/data-source.tf
@@ -1,0 +1,5 @@
+data "rustfs_groups" "all" {}
+
+output "group_names" {
+  value = data.rustfs_groups.all.groups
+}

--- a/pkg/rustfs/group.go
+++ b/pkg/rustfs/group.go
@@ -3,7 +3,10 @@ package rustfs
 import (
 	"context"
 	"encoding/json"
+	"errors"
+	"io"
 	"net/url"
+	"sort"
 )
 
 type GroupInfo struct {
@@ -17,6 +20,44 @@ type GroupAddRemove struct {
 	Members  []string `json:"members"`
 	IsRemove bool     `json:"is_remove"`
 	Status   string   `json:"status"`
+}
+
+// ListGroups returns the names of all IAM groups. The API returns a plain
+// JSON array of group name strings; a {"groups": [...]} wrapper is also
+// accepted for forward compatibility. Names are sorted for deterministic
+// output.
+func (c *RustfsAdmin) ListGroups() ([]string, error) {
+	reqData := RequestData{
+		Method:  "GET",
+		RelPath: "groups",
+	}
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	resp, err := c.doRequest(ctx, reqData)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, err
+	}
+
+	var names []string
+	if err := json.Unmarshal(body, &names); err == nil {
+		sort.Strings(names)
+		return names, nil
+	}
+
+	var wrapped struct {
+		Groups []string `json:"groups"`
+	}
+	if err := json.Unmarshal(body, &wrapped); err == nil {
+		sort.Strings(wrapped.Groups)
+		return wrapped.Groups, nil
+	}
+
+	return nil, errors.New("unrecognized groups response")
 }
 
 func (c *RustfsAdmin) GetGroup(name string) (GroupInfo, error) {

--- a/pkg/rustfs/groups_test.go
+++ b/pkg/rustfs/groups_test.go
@@ -1,0 +1,64 @@
+package rustfs
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"reflect"
+	"testing"
+)
+
+func TestListGroups(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodGet {
+			t.Errorf("expected GET, got %s", r.Method)
+		}
+		if r.URL.Path != "/rustfs/admin/v3/groups" {
+			t.Errorf("wrong path: %s", r.URL.Path)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`["developers","ops"]`))
+	}))
+	defer server.Close()
+
+	client := New(&RustfsAdminConfig{
+		Endpoint:  server.Listener.Addr().String(),
+		AccessKey: "admin",
+	})
+	client.accessSecret = "secret"
+
+	names, err := client.ListGroups()
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !reflect.DeepEqual(names, []string{"developers", "ops"}) {
+		t.Errorf("unexpected groups: %v", names)
+	}
+}
+
+func TestListGroupsWrapped(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodGet {
+			t.Errorf("expected GET, got %s", r.Method)
+		}
+		if r.URL.Path != "/rustfs/admin/v3/groups" {
+			t.Errorf("wrong path: %s", r.URL.Path)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"groups":["ops","developers"]}`))
+	}))
+	defer server.Close()
+
+	client := New(&RustfsAdminConfig{
+		Endpoint:  server.Listener.Addr().String(),
+		AccessKey: "admin",
+	})
+	client.accessSecret = "secret"
+
+	names, err := client.ListGroups()
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !reflect.DeepEqual(names, []string{"developers", "ops"}) {
+		t.Errorf("unexpected groups: %v", names)
+	}
+}

--- a/provider/provider.go
+++ b/provider/provider.go
@@ -148,6 +148,7 @@ func (p *RustfsProvider) DataSources(ctx context.Context) []func() datasource.Da
 		NewUsersDataSource,
 		NewIAMPoliciesDataSource,
 		NewIAMPolicyDataSource,
+		NewGroupsDataSource,
 	}
 }
 

--- a/provider/rustfs_groups_data_source.go
+++ b/provider/rustfs_groups_data_source.go
@@ -1,0 +1,78 @@
+package provider
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/hashicorp/terraform-plugin-framework/datasource"
+	"github.com/hashicorp/terraform-plugin-framework/datasource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+)
+
+var _ datasource.DataSource = &GroupsDataSource{}
+
+type GroupsDataSource struct {
+	client *AllClient
+}
+
+type GroupsDataSourceModel struct {
+	Groups types.Set `tfsdk:"groups"`
+}
+
+func NewGroupsDataSource() datasource.DataSource {
+	return &GroupsDataSource{}
+}
+
+func (d *GroupsDataSource) Metadata(_ context.Context, req datasource.MetadataRequest, resp *datasource.MetadataResponse) {
+	resp.TypeName = req.ProviderTypeName + "_groups"
+}
+
+func (d *GroupsDataSource) Schema(_ context.Context, _ datasource.SchemaRequest, resp *datasource.SchemaResponse) {
+	resp.Schema = schema.Schema{
+		Description:         "Lists all IAM groups for RustFS",
+		MarkdownDescription: "Lists all IAM groups for RustFS",
+		Attributes: map[string]schema.Attribute{
+			"groups": schema.SetAttribute{
+				Computed:            true,
+				ElementType:         types.StringType,
+				Description:         "Set of IAM group names",
+				MarkdownDescription: "Set of IAM group names",
+			},
+		},
+	}
+}
+
+func (d *GroupsDataSource) Configure(_ context.Context, req datasource.ConfigureRequest, resp *datasource.ConfigureResponse) {
+	if req.ProviderData == nil {
+		return
+	}
+	client, ok := req.ProviderData.(*AllClient)
+	if !ok {
+		resp.Diagnostics.AddError(
+			"Unexpected Data Source Configure Type",
+			fmt.Sprintf("Expected *AllClient, got: %T. Please report this issue to the provider developers.", req.ProviderData),
+		)
+		return
+	}
+	d.client = client
+}
+
+func (d *GroupsDataSource) Read(ctx context.Context, _ datasource.ReadRequest, resp *datasource.ReadResponse) {
+	names, err := d.client.RustClient.ListGroups()
+	if err != nil {
+		resp.Diagnostics.AddError(
+			"Error listing groups",
+			"Could not list groups: "+err.Error(),
+		)
+		return
+	}
+	set, diags := types.SetValueFrom(ctx, types.StringType, names)
+	resp.Diagnostics.Append(diags...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+	state := GroupsDataSourceModel{
+		Groups: set,
+	}
+	resp.Diagnostics.Append(resp.State.Set(ctx, &state)...)
+}

--- a/provider/rustfs_groups_data_source_test.go
+++ b/provider/rustfs_groups_data_source_test.go
@@ -1,0 +1,72 @@
+package provider
+
+import (
+	"bytes"
+	"crypto/sha256"
+	"encoding/hex"
+	"fmt"
+	"net/http"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/minio/minio-go/v7/pkg/signer"
+)
+
+func TestAccGroupsDataSource(t *testing.T) {
+	groupName := fmt.Sprintf("tf-acc-groups-%d", time.Now().UnixNano())
+	createAccTestGroup(t, groupName)
+	defer deleteAccTestGroup(t, groupName)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccProviderConfig() + `
+data "rustfs_groups" "all" {}
+`,
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttrSet("data.rustfs_groups.all", "groups.#"),
+					resource.TestCheckTypeSetElemAttr("data.rustfs_groups.all", "groups.*", groupName),
+				),
+			},
+		},
+	})
+}
+
+func createAccTestGroup(t *testing.T, name string) {
+	t.Helper()
+	body := []byte(fmt.Sprintf(`{"group":%q,"members":[],"isRemove":false,"groupStatus":"enabled"}`, name))
+	accAdminRequest(t, http.MethodPut, "update-group-members", body)
+}
+
+func deleteAccTestGroup(t *testing.T, name string) {
+	t.Helper()
+	accAdminRequest(t, http.MethodDelete, "group/"+name, nil)
+}
+
+func accAdminRequest(t *testing.T, method, relPath string, body []byte) {
+	t.Helper()
+	url := "http://" + os.Getenv("RUSTFS_ENDPOINT") + "/rustfs/admin/v3/" + relPath
+	req, err := http.NewRequest(method, url, bytes.NewReader(body))
+	if err != nil {
+		t.Fatalf("failed to build request: %v", err)
+	}
+	if len(body) > 0 {
+		req.ContentLength = int64(len(body))
+	}
+	sum := sha256.Sum256(body)
+	req.Header.Set("X-Amz-Content-Sha256", hex.EncodeToString(sum[:]))
+	req = signer.SignV4(*req, os.Getenv("RUSTFS_USER"), os.Getenv("RUSTFS_SECRET"), "", "us-east-01")
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("admin request failed: %v", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode > 299 {
+		t.Fatalf("admin request %s %s returned status %d", method, relPath, resp.StatusCode)
+	}
+}


### PR DESCRIPTION
**Issue:** https://github.com/weinmann-emt/terraform-provider-rustfs/issues/117

Add a `rustfs_groups` data source listing all IAM groups.

Closes #117

## Changes
- `pkg/rustfs/group.go`: `ListGroups()` (`GET /rustfs/admin/v3/groups`).
- `provider/rustfs_groups_datasource.go`, registered in `DataSources()`.
- Unit (httptest) + acceptance tests; docs + example.

## Testing
- `go build`, `go vet`, gofmt clean; golangci-lint no new findings.
- Unit + acceptance tests pass against a live RustFS.

## Note
Verified: `/v3/groups` returns a plain array (`["g1"]`), not `{"groups":[...]}`; schema is a `groups` Set of String.
