### PR TITLE
feat: add rustfs_config resource (#118)

### DIFF
--- a/docs/resources/config.md
+++ b/docs/resources/config.md
@@ -1,0 +1,45 @@
+---
+page_title: "rustfs_config Resource - rustfs"
+description: |-
+  Manage server sub-system configuration (config-kv)
+---
+
+# rustfs_config (Resource)
+
+Manage server sub-system configuration (config-kv), the `mc admin config` equivalent. Each resource manages one sub-system scope.
+
+## Example Usage
+
+```terraform
+resource "rustfs_config" "primary" {
+  sub_system = "notify_webhook:primary"
+  settings = {
+    endpoint = "http://notify.example.com/rustfs/events"
+  }
+}
+```
+
+## Schema
+
+### Required
+
+- `sub_system` (String) Sub-system scope to manage, e.g. `notify_webhook` or `notify_webhook:primary`. Changing this forces recreation.
+- `settings` (Map of String) Key/value settings applied to the sub-system scope.
+
+### Read-Only
+
+- `id` (String) Resource identifier (the sub-system scope).
+
+## Import
+
+Import is supported using the sub-system scope:
+
+```
+terraform import rustfs_config.example notify_webhook:primary
+```
+
+## Limitations
+
+- The resource manages a single sub-system scope (`subsystem` or `subsystem:target`). Multi-target sub-systems (e.g. `notify_webhook`) require an explicit `:target` suffix per resource.
+- The server only renders non-default settings in `get-config-kv`. Keys whose value matches the server default (or that the server hides, such as `enable` when enabled) are not returned by Read and will show a perpetual diff. Configure only keys that round-trip through `get-config-kv`.
+- `Delete` removes the whole scope (sub-system or target), resetting it to server defaults.

--- a/examples/resources/rustfs_config/resource.tf
+++ b/examples/resources/rustfs_config/resource.tf
@@ -1,0 +1,6 @@
+resource "rustfs_config" "primary" {
+  sub_system = "notify_webhook:primary"
+  settings = {
+    endpoint = "http://notify.example.com/rustfs/events"
+  }
+}

--- a/pkg/rustfs/config.go
+++ b/pkg/rustfs/config.go
@@ -1,0 +1,223 @@
+package rustfs
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/url"
+	"strings"
+)
+
+// ConfigKV is a single key/value pair of a sub-system config scope.
+type ConfigKV struct {
+	Key   string
+	Value string
+}
+
+// configHelpResponse is the JSON envelope returned by help-config-kv.
+type configHelpResponse struct {
+	SubSys          string `json:"subSys"`
+	Description     string `json:"description"`
+	MultipleTargets bool   `json:"multipleTargets"`
+	KeysHelp        []struct {
+		Key             string `json:"key"`
+		Type            string `json:"type"`
+		Description     string `json:"description"`
+		Optional        bool   `json:"optional"`
+		MultipleTargets bool   `json:"multipleTargets"`
+	} `json:"keysHelp"`
+}
+
+// GetConfig returns the current KV settings of a config scope from GET get-config-kv.
+//
+// subSystem is a config scope: either a bare sub-system (e.g. "scanner") or a
+// targeted sub-system (e.g. "notify_webhook:primary"). The server renders the
+// scope as text lines in the form `scope key="value" key2="value2"`.
+func (c *RustfsAdmin) GetConfig(subSystem string) ([]ConfigKV, error) {
+	query := make(url.Values)
+	query.Set("key", subSystem)
+	reqData := RequestData{
+		Method:      "GET",
+		RelPath:     "get-config-kv",
+		QueryValues: query,
+	}
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	resp, err := c.doRequest(ctx, reqData)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, err
+	}
+	return parseConfigKVs(string(body))
+}
+
+// SetConfig sets the KV settings of a config scope via PUT set-config-kv.
+//
+// The request body is a plain text config directive in the same format the
+// server renders: `scope key="value" key2="value2"`.
+func (c *RustfsAdmin) SetConfig(subSystem string, kvs []ConfigKV) error {
+	reqData := RequestData{
+		Method:  "PUT",
+		RelPath: "set-config-kv",
+		Content: []byte(buildConfigDirective(subSystem, kvs)),
+	}
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	_, err := c.doRequest(ctx, reqData)
+	return err
+}
+
+// DeleteConfig removes a config scope via DELETE del-config-kv. The whole
+// sub-system or the named target is removed; keys that are not explicitly
+// listed are also removed, so this resets the scope to the server defaults.
+func (c *RustfsAdmin) DeleteConfig(subSystem string) error {
+	reqData := RequestData{
+		Method:  "DELETE",
+		RelPath: "del-config-kv",
+		Content: []byte(subSystem),
+	}
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	_, err := c.doRequest(ctx, reqData)
+	return err
+}
+
+// HelpConfig returns the documented keys of a sub-system via GET help-config-kv.
+// The returned ConfigKV pairs map each key to its value type hint.
+func (c *RustfsAdmin) HelpConfig(subSystem string) ([]ConfigKV, error) {
+	query := make(url.Values)
+	query.Set("subSys", subSystem)
+	reqData := RequestData{
+		Method:      "GET",
+		RelPath:     "help-config-kv",
+		QueryValues: query,
+	}
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	resp, err := c.doRequest(ctx, reqData)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+	var out configHelpResponse
+	if err := json.NewDecoder(resp.Body).Decode(&out); err != nil {
+		return nil, err
+	}
+	kvs := make([]ConfigKV, 0, len(out.KeysHelp))
+	for _, entry := range out.KeysHelp {
+		kvs = append(kvs, ConfigKV{Key: entry.Key, Value: entry.Type})
+	}
+	return kvs, nil
+}
+
+// buildConfigDirective renders a config scope and its key/value pairs in the
+// text format the set-config-kv endpoint accepts and the server renders.
+func buildConfigDirective(subSystem string, kvs []ConfigKV) string {
+	parts := make([]string, 0, len(kvs)+1)
+	parts = append(parts, subSystem)
+	for _, kv := range kvs {
+		parts = append(parts, kv.Key+`="`+escapeConfigValue(kv.Value)+`"`)
+	}
+	return strings.Join(parts, " ")
+}
+
+// escapeConfigValue mirrors the server-side escaping of config values.
+func escapeConfigValue(value string) string {
+	value = strings.ReplaceAll(value, `\`, `\\`)
+	value = strings.ReplaceAll(value, `"`, `\"`)
+	return value
+}
+
+// parseConfigKVs parses the text/plain body returned by get-config-kv into a
+// flat list of key/value pairs. Comment lines (env override hints) are skipped.
+func parseConfigKVs(text string) ([]ConfigKV, error) {
+	var kvs []ConfigKV
+	for _, line := range strings.Split(text, "\n") {
+		line = strings.TrimSpace(line)
+		if line == "" || strings.HasPrefix(line, "#") {
+			continue
+		}
+		lineKVs, err := parseConfigLine(line)
+		if err != nil {
+			return nil, err
+		}
+		kvs = append(kvs, lineKVs...)
+	}
+	return kvs, nil
+}
+
+// parseConfigLine parses a single rendered config line of the form
+// `scope key="value" key2="value2"` and returns its key/value pairs.
+func parseConfigLine(line string) ([]ConfigKV, error) {
+	tokens, err := tokenizeConfigLine(line)
+	if err != nil {
+		return nil, err
+	}
+	if len(tokens) < 2 {
+		return nil, nil
+	}
+	kvs := make([]ConfigKV, 0, len(tokens)-1)
+	for _, token := range tokens[1:] {
+		key, value, ok := strings.Cut(token, "=")
+		if !ok {
+			return nil, fmt.Errorf("config assignment must use key=value syntax: %q", token)
+		}
+		kvs = append(kvs, ConfigKV{Key: key, Value: value})
+	}
+	return kvs, nil
+}
+
+// tokenizeConfigLine splits a config line into tokens, honoring the quoting and
+// backslash escaping rules used by the server's config parser.
+func tokenizeConfigLine(line string) ([]string, error) {
+	var tokens []string
+	var current strings.Builder
+	var quote byte
+	escaped := false
+	for i := 0; i < len(line); i++ {
+		ch := line[i]
+		if escaped {
+			current.WriteByte(ch)
+			escaped = false
+			continue
+		}
+		if ch == '\\' {
+			escaped = true
+			continue
+		}
+		if quote != 0 {
+			if ch == quote {
+				quote = 0
+			} else {
+				current.WriteByte(ch)
+			}
+			continue
+		}
+		switch ch {
+		case '"', '\'':
+			quote = ch
+		case ' ', '\t':
+			if current.Len() > 0 {
+				tokens = append(tokens, current.String())
+				current.Reset()
+			}
+		default:
+			current.WriteByte(ch)
+		}
+	}
+	if escaped {
+		current.WriteByte('\\')
+	}
+	if quote != 0 {
+		return nil, fmt.Errorf("unterminated quoted config value")
+	}
+	if current.Len() > 0 {
+		tokens = append(tokens, current.String())
+	}
+	return tokens, nil
+}

--- a/pkg/rustfs/config_test.go
+++ b/pkg/rustfs/config_test.go
@@ -1,0 +1,161 @@
+package rustfs_test
+
+import (
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/weinmann-emt/terraform-provider-rustfs/pkg/rustfs"
+)
+
+func newTestConfigAdminServer(t *testing.T, handler http.HandlerFunc) *rustfs.RustfsAdmin {
+	t.Helper()
+	srv := httptest.NewServer(handler)
+	t.Cleanup(srv.Close)
+	c := rustfs.New(&rustfs.RustfsAdminConfig{
+		AccessKey:    "admin",
+		AccessSecret: "secret",
+		Endpoint:     strings.TrimPrefix(srv.URL, "http://"),
+	})
+	return &c
+}
+
+func TestGetConfig(t *testing.T) {
+	var gotPath string
+	client := newTestConfigAdminServer(t, func(w http.ResponseWriter, r *http.Request) {
+		gotPath = r.URL.Path + "?" + r.URL.RawQuery
+		w.Header().Set("Content-Type", "text/plain; charset=utf-8")
+		_, _ = w.Write([]byte(
+			"# RUSTFS_NOTIFY_WEBHOOK_ENDPOINT=http://example.com/rustfs/events\n" +
+				`notify_webhook:primary endpoint="http://example.com/rustfs/events" enable="off"`,
+		))
+	})
+	kvs, err := client.GetConfig("notify_webhook:primary")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !strings.Contains(gotPath, "/get-config-kv") || !strings.Contains(gotPath, "key=notify_webhook%3Aprimary") {
+		t.Errorf("wrong request: %s", gotPath)
+	}
+	if len(kvs) != 2 {
+		t.Fatalf("expected 2 kvs, got %d: %+v", len(kvs), kvs)
+	}
+	if kvs[0].Key != "endpoint" || kvs[0].Value != "http://example.com/rustfs/events" {
+		t.Errorf("unexpected first kv: %+v", kvs[0])
+	}
+	if kvs[1].Key != "enable" || kvs[1].Value != "off" {
+		t.Errorf("unexpected second kv: %+v", kvs[1])
+	}
+}
+
+func TestGetConfigEscapedValue(t *testing.T) {
+	client := newTestConfigAdminServer(t, func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "text/plain; charset=utf-8")
+		_, _ = w.Write([]byte(`notify_webhook:primary endpoint="http://example.com/a\"b\\c"`))
+	})
+	kvs, err := client.GetConfig("notify_webhook:primary")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(kvs) != 1 || kvs[0].Value != `http://example.com/a"b\c` {
+		t.Errorf("unexpected kvs: %+v", kvs)
+	}
+}
+
+func TestGetConfigNotFound(t *testing.T) {
+	client := newTestConfigAdminServer(t, func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusBadRequest)
+		_, _ = w.Write([]byte("config target 'missing' not found for subsystem 'notify_webhook'"))
+	})
+	_, err := client.GetConfig("notify_webhook:missing")
+	if err == nil || !strings.Contains(err.Error(), "not found") {
+		t.Fatalf("expected not found error, got: %v", err)
+	}
+}
+
+func TestSetConfig(t *testing.T) {
+	var gotPath string
+	var gotBody []byte
+	client := newTestConfigAdminServer(t, func(w http.ResponseWriter, r *http.Request) {
+		gotPath = r.URL.Path
+		gotBody, _ = io.ReadAll(r.Body)
+		w.WriteHeader(http.StatusOK)
+	})
+	kvs := []rustfs.ConfigKV{{Key: "endpoint", Value: "http://example.com/rustfs/events"}}
+	if err := client.SetConfig("notify_webhook:primary", kvs); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !strings.Contains(gotPath, "/set-config-kv") {
+		t.Errorf("wrong path: %s", gotPath)
+	}
+	expected := `notify_webhook:primary endpoint="http://example.com/rustfs/events"`
+	if string(gotBody) != expected {
+		t.Errorf("unexpected body: %q, want %q", string(gotBody), expected)
+	}
+}
+
+func TestSetConfigEscapesValue(t *testing.T) {
+	var gotBody []byte
+	client := newTestConfigAdminServer(t, func(w http.ResponseWriter, r *http.Request) {
+		gotBody, _ = io.ReadAll(r.Body)
+		w.WriteHeader(http.StatusOK)
+	})
+	kvs := []rustfs.ConfigKV{{Key: "auth_token", Value: `a"b\c`}}
+	if err := client.SetConfig("notify_webhook", kvs); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	expected := `notify_webhook auth_token="a\"b\\c"`
+	if string(gotBody) != expected {
+		t.Errorf("unexpected body: %q, want %q", string(gotBody), expected)
+	}
+}
+
+func TestDeleteConfig(t *testing.T) {
+	var gotPath string
+	var gotBody []byte
+	client := newTestConfigAdminServer(t, func(w http.ResponseWriter, r *http.Request) {
+		gotPath = r.URL.Path
+		gotBody, _ = io.ReadAll(r.Body)
+		w.WriteHeader(http.StatusOK)
+	})
+	if err := client.DeleteConfig("notify_webhook:primary"); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !strings.Contains(gotPath, "/del-config-kv") {
+		t.Errorf("wrong path: %s", gotPath)
+	}
+	if string(gotBody) != "notify_webhook:primary" {
+		t.Errorf("unexpected body: %q", string(gotBody))
+	}
+}
+
+func TestHelpConfig(t *testing.T) {
+	client := newTestConfigAdminServer(t, func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/rustfs/admin/v3/help-config-kv" {
+			t.Errorf("wrong path: %s", r.URL.Path)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]interface{}{
+			"subSys":          "notify_webhook",
+			"description":     "publish bucket notifications to webhook endpoints",
+			"multipleTargets": true,
+			"keysHelp": []map[string]interface{}{
+				{"key": "endpoint", "type": "url", "description": "webhook server endpoint", "optional": false, "multipleTargets": false},
+				{"key": "enable", "type": "on|off", "description": "enable target", "optional": false, "multipleTargets": false},
+			},
+		})
+	})
+	kvs, err := client.HelpConfig("notify_webhook")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(kvs) != 2 || kvs[0].Key != "endpoint" || kvs[0].Value != "url" {
+		t.Errorf("unexpected kvs: %+v", kvs)
+	}
+	if kvs[1].Key != "enable" || kvs[1].Value != "on|off" {
+		t.Errorf("unexpected kvs: %+v", kvs)
+	}
+}

--- a/provider/provider.go
+++ b/provider/provider.go
@@ -137,6 +137,7 @@ func (p *RustfsProvider) Resources(ctx context.Context) []func() resource.Resour
 		NewBucketReplicationResource,
 		NewBucketEncryptionResource,
 		NewBucketVersioningResource,
+		NewConfigRessource,
 	}
 }
 

--- a/provider/rustfs_config_ressource.go
+++ b/provider/rustfs_config_ressource.go
@@ -1,0 +1,195 @@
+package provider
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/hashicorp/terraform-plugin-framework/path"
+	"github.com/hashicorp/terraform-plugin-framework/resource"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/weinmann-emt/terraform-provider-rustfs/pkg/rustfs"
+)
+
+var (
+	_ resource.Resource                = &ConfigRessource{}
+	_ resource.ResourceWithImportState = &ConfigRessource{}
+)
+
+type ConfigRessourceModel struct {
+	SubSystem types.String `tfsdk:"sub_system"`
+	Settings  types.Map    `tfsdk:"settings"`
+	ID        types.String `tfsdk:"id"`
+}
+
+func NewConfigRessource() resource.Resource {
+	return &ConfigRessource{}
+}
+
+type ConfigRessource struct {
+	client *AllClient
+}
+
+func (r *ConfigRessource) Metadata(_ context.Context, req resource.MetadataRequest, resp *resource.MetadataResponse) {
+	resp.TypeName = req.ProviderTypeName + "_config"
+}
+
+func (r *ConfigRessource) Schema(_ context.Context, _ resource.SchemaRequest, resp *resource.SchemaResponse) {
+	resp.Schema = schema.Schema{
+		Description:         "Manage server sub-system configuration (config-kv)",
+		MarkdownDescription: "Manage server sub-system configuration (config-kv), the `mc admin config` equivalent. Each resource manages one sub-system scope.",
+		Attributes: map[string]schema.Attribute{
+			"sub_system": schema.StringAttribute{
+				Required:    true,
+				Description: "Sub-system scope to manage, e.g. `notify_webhook` or `notify_webhook:primary`. Changing this forces recreation.",
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.RequiresReplace(),
+				},
+			},
+			"settings": schema.MapAttribute{
+				Required:    true,
+				ElementType: types.StringType,
+				Description: "Key/value settings applied to the sub-system scope.",
+			},
+			"id": schema.StringAttribute{
+				Computed:    true,
+				Description: "Resource identifier (the sub-system scope).",
+			},
+		},
+	}
+}
+
+func (r *ConfigRessource) Configure(_ context.Context, req resource.ConfigureRequest, resp *resource.ConfigureResponse) {
+	if req.ProviderData == nil {
+		return
+	}
+	client, ok := req.ProviderData.(*AllClient)
+	if !ok {
+		resp.Diagnostics.AddError(
+			"Unexpected Resource Configure Type",
+			fmt.Sprintf("Expected *AllClient, got: %T. Please report this issue to the provider developers.", req.ProviderData),
+		)
+		return
+	}
+	r.client = client
+}
+
+func configKVsFromSettings(settings types.Map) ([]rustfs.ConfigKV, error) {
+	elements := settings.Elements()
+	kvs := make([]rustfs.ConfigKV, 0, len(elements))
+	for key, value := range elements {
+		str, ok := value.(types.String)
+		if !ok {
+			return nil, fmt.Errorf("unexpected value type for setting %q: %T", key, value)
+		}
+		kvs = append(kvs, rustfs.ConfigKV{Key: key, Value: str.ValueString()})
+	}
+	return kvs, nil
+}
+
+func settingsFromConfigKVs(ctx context.Context, kvs []rustfs.ConfigKV) types.Map {
+	settings := make(map[string]string, len(kvs))
+	for _, kv := range kvs {
+		settings[kv.Key] = kv.Value
+	}
+	value, diags := types.MapValueFrom(ctx, types.StringType, settings)
+	if diags.HasError() {
+		return types.MapNull(types.StringType)
+	}
+	return value
+}
+
+func (r *ConfigRessource) Create(ctx context.Context, req resource.CreateRequest, resp *resource.CreateResponse) {
+	var plan ConfigRessourceModel
+	resp.Diagnostics.Append(req.Plan.Get(ctx, &plan)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	kvs, err := configKVsFromSettings(plan.Settings)
+	if err != nil {
+		resp.Diagnostics.AddError("Error parsing settings", err.Error())
+		return
+	}
+	if err := r.client.RustClient.SetConfig(plan.SubSystem.ValueString(), kvs); err != nil {
+		resp.Diagnostics.AddError(
+			"Error setting config",
+			"Could not set config, unexpected error: "+err.Error(),
+		)
+		return
+	}
+
+	plan.ID = plan.SubSystem
+	resp.Diagnostics.Append(resp.State.Set(ctx, &plan)...)
+}
+
+func (r *ConfigRessource) Read(ctx context.Context, req resource.ReadRequest, resp *resource.ReadResponse) {
+	var state ConfigRessourceModel
+	resp.Diagnostics.Append(req.State.Get(ctx, &state)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	kvs, err := r.client.RustClient.GetConfig(state.SubSystem.ValueString())
+	if err != nil {
+		if strings.Contains(err.Error(), "not found") {
+			resp.State.RemoveResource(ctx)
+			return
+		}
+		resp.Diagnostics.AddError(
+			"Error reading config",
+			"Could not read config, unexpected error: "+err.Error(),
+		)
+		return
+	}
+
+	state.Settings = settingsFromConfigKVs(ctx, kvs)
+	state.ID = state.SubSystem
+	resp.Diagnostics.Append(resp.State.Set(ctx, &state)...)
+}
+
+func (r *ConfigRessource) Update(ctx context.Context, req resource.UpdateRequest, resp *resource.UpdateResponse) {
+	var plan ConfigRessourceModel
+	resp.Diagnostics.Append(req.Plan.Get(ctx, &plan)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	kvs, err := configKVsFromSettings(plan.Settings)
+	if err != nil {
+		resp.Diagnostics.AddError("Error parsing settings", err.Error())
+		return
+	}
+	if err := r.client.RustClient.SetConfig(plan.SubSystem.ValueString(), kvs); err != nil {
+		resp.Diagnostics.AddError(
+			"Error updating config",
+			"Could not update config, unexpected error: "+err.Error(),
+		)
+		return
+	}
+
+	plan.ID = plan.SubSystem
+	resp.Diagnostics.Append(resp.State.Set(ctx, &plan)...)
+}
+
+func (r *ConfigRessource) Delete(ctx context.Context, req resource.DeleteRequest, resp *resource.DeleteResponse) {
+	var data ConfigRessourceModel
+	resp.Diagnostics.Append(req.State.Get(ctx, &data)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	if err := r.client.RustClient.DeleteConfig(data.SubSystem.ValueString()); err != nil {
+		resp.Diagnostics.AddError(
+			"Error deleting config",
+			"Could not delete config, unexpected error: "+err.Error(),
+		)
+	}
+}
+
+func (r *ConfigRessource) ImportState(ctx context.Context, req resource.ImportStateRequest, resp *resource.ImportStateResponse) {
+	resource.ImportStatePassthroughID(ctx, path.Root("sub_system"), req, resp)
+}

--- a/provider/rustfs_config_ressource_test.go
+++ b/provider/rustfs_config_ressource_test.go
@@ -1,0 +1,85 @@
+package provider
+
+import (
+	"fmt"
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-testing/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/terraform"
+	"github.com/weinmann-emt/terraform-provider-rustfs/pkg/rustfs"
+)
+
+func TestAccConfigResource(t *testing.T) {
+	scope := fmt.Sprintf("notify_webhook:tfaccept%d", acctest.RandInt())
+	resourceName := "rustfs_config.test"
+
+	// Pre-cleanup in case a previous interrupted run left the target behind.
+	client := rustfs.New(&rustfs.RustfsAdminConfig{
+		AccessKey:    os.Getenv("RUSTFS_USER"),
+		AccessSecret: os.Getenv("RUSTFS_SECRET"),
+		Endpoint:     os.Getenv("RUSTFS_ENDPOINT"),
+		Ssl:          false,
+	})
+	_ = client.DeleteConfig(scope)
+
+	resource.Test(t, resource.TestCase{
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		PreCheck:                 func() { testAccPreCheck(t) },
+		CheckDestroy:             testAccCheckConfigDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccConfigConfig(scope, "http://127.0.0.1:18080/rustfs/events"),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceName, "sub_system", scope),
+					resource.TestCheckResourceAttr(resourceName, "settings.endpoint", "http://127.0.0.1:18080/rustfs/events"),
+					resource.TestCheckResourceAttrSet(resourceName, "id"),
+				),
+			},
+			{
+				Config: testAccConfigConfig(scope, "http://127.0.0.1:18080/rustfs/events_v2"),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceName, "settings.endpoint", "http://127.0.0.1:18080/rustfs/events_v2"),
+				),
+			},
+		},
+	})
+}
+
+func testAccConfigConfig(scope, endpoint string) string {
+	return fmt.Sprintf(testAccProviderConfig()+`
+resource "rustfs_config" "test" {
+  sub_system = "%s"
+  settings = {
+    endpoint = "%s"
+  }
+}
+`, scope, endpoint)
+}
+
+// testAccCheckConfigDestroy verifies the config scope was removed so the
+// server configuration is left unchanged when the test exits.
+func testAccCheckConfigDestroy(s *terraform.State) error {
+	for _, rs := range s.RootModule().Resources {
+		if rs.Type != "rustfs_config" {
+			continue
+		}
+		scope := rs.Primary.Attributes["sub_system"]
+		client := rustfs.New(&rustfs.RustfsAdminConfig{
+			AccessKey:    os.Getenv("RUSTFS_USER"),
+			AccessSecret: os.Getenv("RUSTFS_SECRET"),
+			Endpoint:     os.Getenv("RUSTFS_ENDPOINT"),
+			Ssl:          false,
+		})
+		_, err := client.GetConfig(scope)
+		if err == nil {
+			return fmt.Errorf("config scope %s still exists after destroy", scope)
+		}
+		if !strings.Contains(err.Error(), "not found") {
+			return err
+		}
+	}
+	return nil
+}


### PR DESCRIPTION
**Issue:** https://github.com/weinmann-emt/terraform-provider-rustfs/issues/118

Add a `rustfs_config` resource to manage server sub-system configuration (config-kv, the `mc admin config` equivalent).

Closes #118

## Changes
- `pkg/rustfs/config.go`: get/set/delete client for the config-kv endpoints.
- `provider/rustfs_config_ressource.go` (`sub_system` scope + `settings` map), registered in `Resources()`.
- Unit (httptest) + acceptance tests; docs + example.

## Testing
- `go build`, `go vet`, gofmt clean; golangci-lint no new findings.
- 7/7 httptest unit tests + acceptance test pass against a live RustFS (config verified restored after test).

## Note
Verified against RustFS source + live server: config-kv uses plain-text directives (`get-config-kv ?key=scope` returns `scope key="value"`; `set`/`del` take text bodies), not the JSON `{KV:[...]}` shape the plan assumed. The server hides default-valued/enabled keys from reads, so only keys that round-trip via `get-config-kv` should be configured (documented).
