### PR TITLE
feat: add rustfs_kms_key resource (#123)

### DIFF
--- a/docs/resources/kms_key.md
+++ b/docs/resources/kms_key.md
@@ -1,0 +1,67 @@
+---
+page_title: "rustfs_kms_key Resource - rustfs"
+subcategory: ""
+description: |-
+  Manage RustFS KMS master keys
+---
+
+# rustfs_kms_key (Resource)
+
+Manage RustFS KMS master keys: create, describe, enable/disable, rotate and
+(safely) delete. The resource covers the master-key lifecycle exposed by the
+RustFS admin API `kms/keys` endpoints.
+
+> **Warning:** Deleting a KMS master key is **critical and irreversible**.
+> RustFS schedules the destruction of the key material behind a pending window
+> (default 30 days) and existing data encrypted under the key becomes
+> permanently undecryptable once the deletion completes. To keep a key around
+> after removing the resource, set `skip_destroy = true`.
+
+## Example Usage
+
+```terraform
+resource "rustfs_kms_key" "app" {
+  name         = "app-master-key"
+  enabled      = true
+  skip_destroy = true
+}
+```
+
+## Schema
+
+### Required
+
+- `name` (String) Name of the KMS master key. Changing this forces recreation.
+
+### Optional
+
+- `enabled` (Boolean) Whether the KMS master key is enabled. Defaults to `true`.
+- `skip_destroy` (Boolean) When `true`, destroy only removes Terraform state and
+  leaves the irreversible server-side key deletion unexecuted. Defaults to
+  `false`.
+
+### Read-Only
+
+- `created_at` (String) Timestamp when the key was created.
+- `key_id` (String) Server-generated id of the KMS master key. On the Local dev
+  backend this equals the key name.
+
+## Import
+
+Import is supported using the key name:
+
+```
+terraform import rustfs_kms_key.app app-master-key
+```
+
+## Backend support
+
+The RustFS Local development backend supports key creation, describe,
+enable/disable and scheduled deletion, but **not rotation** — the server answers
+a rotate request with `501 Not Implemented` (capability `rotate: false`). The
+Static (read-only) backend rejects key creation entirely.
+
+- The acceptance test (`TestAccKmsKeyResource`) probes the running backend and
+  skips gracefully when the backend cannot create keys.
+- To exercise key rotation, run the provider against a production KMS backend
+  (Vault or AWS KMS) that advertises `rotate: true`.

--- a/examples/resources/rustfs_kms_key/resource.tf
+++ b/examples/resources/rustfs_kms_key/resource.tf
@@ -1,0 +1,5 @@
+resource "rustfs_kms_key" "app" {
+  name         = "app-master-key"
+  enabled      = true
+  skip_destroy = true
+}

--- a/pkg/rustfs/kms.go
+++ b/pkg/rustfs/kms.go
@@ -1,0 +1,251 @@
+package rustfs
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+)
+
+// KmsKey describes a KMS master key as returned by the KMS admin API.
+//
+// The wire shape is the key_metadata object of the create/describe/lifecycle
+// responses. `key_state` is the authoritative lifecycle state (Enabled,
+// Disabled or PendingDeletion).
+type KmsKey struct {
+	KeyID        string            `json:"key_id"`
+	KeyState     string            `json:"key_state"`
+	KeyUsage     string            `json:"key_usage"`
+	Description  *string           `json:"description"`
+	CreationDate string            `json:"creation_date"`
+	DeletionDate *string           `json:"deletion_date"`
+	Origin       string            `json:"origin"`
+	KeyManager   string            `json:"key_manager"`
+	Tags         map[string]string `json:"tags"`
+}
+
+// KmsKeyInfo is a single entry in a key listing response.
+type KmsKeyInfo struct {
+	KeyID       string            `json:"key_id"`
+	Description *string           `json:"description"`
+	Algorithm   string            `json:"algorithm"`
+	Usage       string            `json:"usage"`
+	Status      string            `json:"status"`
+	Tags        map[string]string `json:"tags"`
+	CreatedAt   string            `json:"created_at"`
+	CreatedBy   *string           `json:"created_by"`
+}
+
+type kmsCreateResponse struct {
+	Success     bool    `json:"success"`
+	Message     string  `json:"message"`
+	KeyID       string  `json:"key_id"`
+	KeyMetadata *KmsKey `json:"key_metadata"`
+}
+
+type kmsDescribeResponse struct {
+	Success     bool    `json:"success"`
+	Message     string  `json:"message"`
+	KeyMetadata *KmsKey `json:"key_metadata"`
+}
+
+type kmsListResponse struct {
+	Success    bool         `json:"success"`
+	Message    string       `json:"message"`
+	Keys       []KmsKeyInfo `json:"keys"`
+	Truncated  bool         `json:"truncated"`
+	NextMarker *string      `json:"next_marker"`
+}
+
+type kmsLifecycleResponse struct {
+	Success     bool    `json:"success"`
+	Message     string  `json:"message"`
+	KeyID       string  `json:"key_id"`
+	KeyMetadata *KmsKey `json:"key_metadata"`
+}
+
+// CreateKmsKey creates a new KMS master key with the given name.
+//
+// The key name is carried as the `name` tag, which the RustFS create handler
+// turns into the key id for backends that support named keys (Local backend)
+// or into a server-generated key id for production backends.
+func (c *RustfsAdmin) CreateKmsKey(name string) (KmsKey, error) {
+	body := struct {
+		Tags map[string]string `json:"tags"`
+	}{Tags: map[string]string{"name": name}}
+	//#nosec G117 — a KMS key name is a public identifier, not a secret
+	bytes, err := json.Marshal(body)
+	if err != nil {
+		return KmsKey{}, err
+	}
+	reqData := RequestData{
+		Method:  "POST",
+		RelPath: "kms/keys",
+		Content: bytes,
+	}
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	resp, err := c.doRequest(ctx, reqData)
+	if err != nil {
+		return KmsKey{}, err
+	}
+	defer resp.Body.Close()
+	var out kmsCreateResponse
+	if err := json.NewDecoder(resp.Body).Decode(&out); err != nil {
+		return KmsKey{}, err
+	}
+	if out.KeyMetadata != nil {
+		return *out.KeyMetadata, nil
+	}
+	return KmsKey{KeyID: out.KeyID, KeyState: "Enabled", Tags: body.Tags}, nil
+}
+
+// DescribeKmsKey describes a KMS master key by its key id.
+func (c *RustfsAdmin) DescribeKmsKey(keyID string) (KmsKey, error) {
+	reqData := RequestData{
+		Method:  "GET",
+		RelPath: "kms/keys/" + keyID,
+	}
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	resp, err := c.doRequest(ctx, reqData)
+	if err != nil {
+		return KmsKey{}, err
+	}
+	defer resp.Body.Close()
+	var out kmsDescribeResponse
+	if err := json.NewDecoder(resp.Body).Decode(&out); err != nil {
+		return KmsKey{}, err
+	}
+	if out.KeyMetadata == nil {
+		return KmsKey{}, errors.New(out.Message)
+	}
+	return *out.KeyMetadata, nil
+}
+
+// ListKmsKeys lists the KMS master keys known to the server.
+func (c *RustfsAdmin) ListKmsKeys() ([]KmsKeyInfo, error) {
+	reqData := RequestData{
+		Method:  "GET",
+		RelPath: "kms/keys",
+	}
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	resp, err := c.doRequest(ctx, reqData)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+	var out kmsListResponse
+	if err := json.NewDecoder(resp.Body).Decode(&out); err != nil {
+		return nil, err
+	}
+	return out.Keys, nil
+}
+
+// EnableKmsKey enables a KMS master key.
+func (c *RustfsAdmin) EnableKmsKey(keyID string) error {
+	return c.setKmsKeyState(keyID, "kms/keys/enable")
+}
+
+// DisableKmsKey disables a KMS master key.
+func (c *RustfsAdmin) DisableKmsKey(keyID string) error {
+	return c.setKmsKeyState(keyID, "kms/keys/disable")
+}
+
+func (c *RustfsAdmin) setKmsKeyState(keyID, relPath string) error {
+	body := struct {
+		KeyID string `json:"key_id"`
+	}{KeyID: keyID}
+	//#nosec G117 — a KMS key id is a public identifier, not a secret
+	bytes, err := json.Marshal(body)
+	if err != nil {
+		return err
+	}
+	reqData := RequestData{
+		Method:  "POST",
+		RelPath: relPath,
+		Content: bytes,
+	}
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	resp, err := c.doRequest(ctx, reqData)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+	var out kmsLifecycleResponse
+	if err := json.NewDecoder(resp.Body).Decode(&out); err != nil {
+		return err
+	}
+	if !out.Success {
+		return errors.New(out.Message)
+	}
+	return nil
+}
+
+// RotateKmsKey rotates a KMS master key and returns the key's new metadata.
+//
+// Note that the Local development backend does not support rotation: the
+// server answers with a 501 (KmsError::UnsupportedCapability) for backends
+// whose capabilities report rotate=false.
+func (c *RustfsAdmin) RotateKmsKey(keyID string) (KmsKey, error) {
+	body := struct {
+		KeyID string `json:"key_id"`
+	}{KeyID: keyID}
+	//#nosec G117 — a KMS key id is a public identifier, not a secret
+	bytes, err := json.Marshal(body)
+	if err != nil {
+		return KmsKey{}, err
+	}
+	reqData := RequestData{
+		Method:  "POST",
+		RelPath: "kms/keys/rotate",
+		Content: bytes,
+	}
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	resp, err := c.doRequest(ctx, reqData)
+	if err != nil {
+		return KmsKey{}, err
+	}
+	defer resp.Body.Close()
+	var out kmsLifecycleResponse
+	if err := json.NewDecoder(resp.Body).Decode(&out); err != nil {
+		return KmsKey{}, err
+	}
+	if out.KeyMetadata == nil {
+		return KmsKey{}, errors.New(out.Message)
+	}
+	return *out.KeyMetadata, nil
+}
+
+// DeleteKmsKey schedules the deletion of a KMS master key.
+//
+// The RustFS admin API marks this route Critical: destroying a master key
+// makes every object encrypted under it permanently unreadable. The server
+// schedules the deletion behind a pending window (default 30 days) unless
+// force_immediate/confirm_key_id are supplied; this client deliberately never
+// sends them, so callers always get the cancellable scheduled deletion.
+func (c *RustfsAdmin) DeleteKmsKey(keyID string) error {
+	body := struct {
+		KeyID string `json:"key_id"`
+	}{KeyID: keyID}
+	//#nosec G117 — a KMS key id is a public identifier, not a secret
+	bytes, err := json.Marshal(body)
+	if err != nil {
+		return err
+	}
+	reqData := RequestData{
+		Method:  "DELETE",
+		RelPath: "kms/keys/delete",
+		Content: bytes,
+	}
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	resp, err := c.doRequest(ctx, reqData)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+	return nil
+}

--- a/pkg/rustfs/kms_test.go
+++ b/pkg/rustfs/kms_test.go
@@ -1,0 +1,232 @@
+package rustfs
+
+import (
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func newKmsTestClient(t *testing.T, handler http.HandlerFunc) *RustfsAdmin {
+	t.Helper()
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Header.Get("X-Amz-Date") == "" {
+			t.Error("expected signed request headers")
+		}
+		handler(w, r)
+	}))
+	t.Cleanup(server.Close)
+
+	client := New(&RustfsAdminConfig{
+		Endpoint:  server.Listener.Addr().String(),
+		AccessKey: "admin",
+	})
+	client.accessSecret = "secret"
+	return &client
+}
+
+func readBody(t *testing.T, body io.Reader) string {
+	t.Helper()
+	b, err := io.ReadAll(body)
+	if err != nil {
+		t.Fatalf("failed to read body: %v", err)
+	}
+	return string(b)
+}
+
+func TestCreateKmsKey(t *testing.T) {
+	client := newKmsTestClient(t, func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost {
+			t.Errorf("expected POST, got %s", r.Method)
+		}
+		if r.URL.Path != "/rustfs/admin/v3/kms/keys" {
+			t.Errorf("wrong path: %s", r.URL.Path)
+		}
+		var body struct {
+			Tags map[string]string `json:"tags"`
+		}
+		if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+			t.Errorf("invalid body: %v", err)
+		}
+		if body.Tags["name"] != "mykey" {
+			t.Errorf("wrong name tag: %s", body.Tags["name"])
+		}
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"success":true,"message":"key created successfully","key_id":"mykey","key_metadata":{"key_id":"mykey","key_state":"Enabled","key_usage":"EncryptDecrypt","creation_date":"2026-09-07T00:00:00Z","origin":"KMS","key_manager":"CUSTOMER","tags":{"name":"mykey"}}}`))
+	})
+
+	key, err := client.CreateKmsKey("mykey")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if key.KeyID != "mykey" {
+		t.Errorf("wrong key id: %s", key.KeyID)
+	}
+	if key.KeyState != "Enabled" {
+		t.Errorf("wrong key state: %s", key.KeyState)
+	}
+	if key.Tags["name"] != "mykey" {
+		t.Errorf("missing name tag: %+v", key.Tags)
+	}
+}
+
+func TestDescribeKmsKey(t *testing.T) {
+	client := newKmsTestClient(t, func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodGet {
+			t.Errorf("expected GET, got %s", r.Method)
+		}
+		if r.URL.Path != "/rustfs/admin/v3/kms/keys/k1" {
+			t.Errorf("wrong path: %s", r.URL.Path)
+		}
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"success":true,"message":"Key described successfully","key_metadata":{"key_id":"k1","key_state":"Disabled","key_usage":"EncryptDecrypt","creation_date":"2026-09-07T00:00:00Z","origin":"KMS","key_manager":"CUSTOMER","tags":{"name":"k1"}},"impact":null}`))
+	})
+
+	key, err := client.DescribeKmsKey("k1")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if key.KeyID != "k1" {
+		t.Errorf("wrong key id: %s", key.KeyID)
+	}
+	if key.KeyState != "Disabled" {
+		t.Errorf("wrong key state: %s", key.KeyState)
+	}
+}
+
+func TestListKmsKeys(t *testing.T) {
+	client := newKmsTestClient(t, func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodGet {
+			t.Errorf("expected GET, got %s", r.Method)
+		}
+		if r.URL.Path != "/rustfs/admin/v3/kms/keys" {
+			t.Errorf("wrong path: %s", r.URL.Path)
+		}
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"success":true,"message":"keys listed successfully","keys":[{"key_id":"k1","status":"Active","created_at":"2026-09-07T00:00:00Z","created_by":"local-kms"},{"key_id":"k2","status":"Active","created_at":"2026-09-07T00:00:00Z"}],"truncated":false,"next_marker":null}`))
+	})
+
+	keys, err := client.ListKmsKeys()
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(keys) != 2 {
+		t.Fatalf("expected 2 keys, got %d", len(keys))
+	}
+	if keys[0].KeyID != "k1" || keys[1].KeyID != "k2" {
+		t.Errorf("wrong keys: %+v", keys)
+	}
+	if keys[0].CreatedBy == nil || *keys[0].CreatedBy != "local-kms" {
+		t.Errorf("wrong created_by: %+v", keys[0].CreatedBy)
+	}
+}
+
+func TestEnableKmsKey(t *testing.T) {
+	client := newKmsTestClient(t, func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost {
+			t.Errorf("expected POST, got %s", r.Method)
+		}
+		if r.URL.Path != "/rustfs/admin/v3/kms/keys/enable" {
+			t.Errorf("wrong path: %s", r.URL.Path)
+		}
+		body := readBody(t, r.Body)
+		var req struct {
+			KeyID string `json:"key_id"`
+		}
+		if err := json.Unmarshal([]byte(body), &req); err != nil {
+			t.Errorf("invalid body: %v", err)
+		}
+		if req.KeyID != "mykey" {
+			t.Errorf("wrong key id: %s", req.KeyID)
+		}
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"success":true,"message":"key enabled successfully","key_id":"mykey","key_metadata":null}`))
+	})
+
+	if err := client.EnableKmsKey("mykey"); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestDisableKmsKey(t *testing.T) {
+	client := newKmsTestClient(t, func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost {
+			t.Errorf("expected POST, got %s", r.Method)
+		}
+		if r.URL.Path != "/rustfs/admin/v3/kms/keys/disable" {
+			t.Errorf("wrong path: %s", r.URL.Path)
+		}
+		var req struct {
+			KeyID string `json:"key_id"`
+		}
+		if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+			t.Errorf("invalid body: %v", err)
+		}
+		if req.KeyID != "mykey" {
+			t.Errorf("wrong key id: %s", req.KeyID)
+		}
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"success":true,"message":"key disabled successfully","key_id":"mykey","key_metadata":null}`))
+	})
+
+	if err := client.DisableKmsKey("mykey"); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestRotateKmsKey(t *testing.T) {
+	client := newKmsTestClient(t, func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost {
+			t.Errorf("expected POST, got %s", r.Method)
+		}
+		if r.URL.Path != "/rustfs/admin/v3/kms/keys/rotate" {
+			t.Errorf("wrong path: %s", r.URL.Path)
+		}
+		var req struct {
+			KeyID string `json:"key_id"`
+		}
+		if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+			t.Errorf("invalid body: %v", err)
+		}
+		if req.KeyID != "mykey" {
+			t.Errorf("wrong key id: %s", req.KeyID)
+		}
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"success":true,"message":"key rotated successfully","key_id":"mykey","key_metadata":{"key_id":"mykey","key_state":"Enabled","creation_date":"2026-09-07T01:00:00Z","origin":"KMS","key_manager":"CUSTOMER"}}`))
+	})
+
+	key, err := client.RotateKmsKey("mykey")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if key.KeyID != "mykey" {
+		t.Errorf("wrong key id: %s", key.KeyID)
+	}
+}
+
+func TestDeleteKmsKey(t *testing.T) {
+	client := newKmsTestClient(t, func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodDelete {
+			t.Errorf("expected DELETE, got %s", r.Method)
+		}
+		if r.URL.Path != "/rustfs/admin/v3/kms/keys/delete" {
+			t.Errorf("wrong path: %s", r.URL.Path)
+		}
+		var req struct {
+			KeyID string `json:"key_id"`
+		}
+		if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+			t.Errorf("invalid body: %v", err)
+		}
+		if req.KeyID != "mykey" {
+			t.Errorf("wrong key id: %s", req.KeyID)
+		}
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"success":true,"message":"key deleted successfully","key_id":"mykey","deletion_date":"2026-10-07T00:00:00Z","impact":null}`))
+	})
+
+	if err := client.DeleteKmsKey("mykey"); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}

--- a/provider/provider.go
+++ b/provider/provider.go
@@ -137,6 +137,7 @@ func (p *RustfsProvider) Resources(ctx context.Context) []func() resource.Resour
 		NewBucketReplicationResource,
 		NewBucketEncryptionResource,
 		NewBucketVersioningResource,
+		NewKmsKeyRessource,
 	}
 }
 

--- a/provider/rustfs_kms_key_ressource.go
+++ b/provider/rustfs_kms_key_ressource.go
@@ -1,0 +1,251 @@
+package provider
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/hashicorp/terraform-plugin-framework/path"
+	"github.com/hashicorp/terraform-plugin-framework/resource"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/booldefault"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/hashicorp/terraform-plugin-log/tflog"
+)
+
+// Ensure the implementation satisfies the expected interfaces.
+var (
+	_ resource.Resource                = &kmsKeyRessource{}
+	_ resource.ResourceWithImportState = &kmsKeyRessource{}
+)
+
+// NewKmsKeyRessource is a helper function to simplify the provider implementation.
+func NewKmsKeyRessource() resource.Resource {
+	return &kmsKeyRessource{}
+}
+
+// kmsKeyRessource is the resource implementation.
+type kmsKeyRessource struct {
+	client *AllClient
+}
+
+type kmsKeyRessourceModel struct {
+	Name        types.String `tfsdk:"name"`
+	KeyID       types.String `tfsdk:"key_id"`
+	CreatedAt   types.String `tfsdk:"created_at"`
+	Enabled     types.Bool   `tfsdk:"enabled"`
+	SkipDestroy types.Bool   `tfsdk:"skip_destroy"`
+}
+
+// Metadata returns the resource type name.
+func (r *kmsKeyRessource) Metadata(_ context.Context, req resource.MetadataRequest, resp *resource.MetadataResponse) {
+	resp.TypeName = req.ProviderTypeName + "_kms_key"
+}
+
+// Schema defines the schema for the resource.
+func (r *kmsKeyRessource) Schema(_ context.Context, _ resource.SchemaRequest, resp *resource.SchemaResponse) {
+	resp.Schema = schema.Schema{
+		Description:         "Manage RustFS KMS master keys",
+		MarkdownDescription: "Manage RustFS KMS master keys. Deleting a KMS master key is **critical and irreversible**: it schedules the destruction of the key material and makes every object encrypted under the key permanently unreadable. Guard the key with `skip_destroy = true`.",
+		Attributes: map[string]schema.Attribute{
+			"name": schema.StringAttribute{
+				Required:      true,
+				Description:   "Name of the KMS master key. Changing this forces recreation.",
+				PlanModifiers: []planmodifier.String{stringplanmodifier.RequiresReplace()},
+			},
+			"key_id": schema.StringAttribute{
+				Computed:    true,
+				Description: "Server-generated id of the KMS master key. On the Local dev backend this equals the key name.",
+			},
+			"created_at": schema.StringAttribute{
+				Computed:    true,
+				Description: "Timestamp when the key was created.",
+			},
+			"enabled": schema.BoolAttribute{
+				Optional:    true,
+				Computed:    true,
+				Default:     booldefault.StaticBool(true),
+				Description: "Whether the KMS master key is enabled. Defaults to `true`.",
+			},
+			"skip_destroy": schema.BoolAttribute{
+				Optional:    true,
+				Computed:    true,
+				Default:     booldefault.StaticBool(false),
+				Description: "When `true`, destroy only removes Terraform state and leaves the irreversible server-side key deletion unexecuted. Defaults to `false`.",
+			},
+		},
+	}
+}
+
+func (r *kmsKeyRessource) Configure(_ context.Context, req resource.ConfigureRequest, resp *resource.ConfigureResponse) {
+	if req.ProviderData == nil {
+		return
+	}
+	client, ok := req.ProviderData.(*AllClient)
+	if !ok {
+		resp.Diagnostics.AddError(
+			"Unexpected Resource Configure Type",
+			fmt.Sprintf("Expected *AllClient, got: %T. Please report this issue to the provider developers.", req.ProviderData),
+		)
+		return
+	}
+	r.client = client
+}
+
+// Create creates the KMS key and sets the initial Terraform state.
+func (r *kmsKeyRessource) Create(ctx context.Context, req resource.CreateRequest, resp *resource.CreateResponse) {
+	var plan kmsKeyRessourceModel
+	resp.Diagnostics.Append(req.Plan.Get(ctx, &plan)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	key, err := r.client.RustClient.CreateKmsKey(plan.Name.ValueString())
+	if err != nil {
+		resp.Diagnostics.AddError(
+			"Error creating KMS key",
+			"Could not create KMS key, unexpected error: "+err.Error(),
+		)
+		return
+	}
+	plan.KeyID = types.StringValue(key.KeyID)
+	plan.CreatedAt = types.StringValue(key.CreationDate)
+
+	if !plan.Enabled.ValueBool() {
+		if err := r.client.RustClient.DisableKmsKey(key.KeyID); err != nil {
+			resp.Diagnostics.AddError(
+				"Error disabling KMS key",
+				"Could not disable KMS key, unexpected error: "+err.Error(),
+			)
+			return
+		}
+	}
+	tflog.Trace(ctx, "created a KMS key")
+	resp.Diagnostics.Append(resp.State.Set(ctx, &plan)...)
+}
+
+// Read refreshes the Terraform state with the latest data.
+func (r *kmsKeyRessource) Read(ctx context.Context, req resource.ReadRequest, resp *resource.ReadResponse) {
+	var state kmsKeyRessourceModel
+	resp.Diagnostics.Append(req.State.Get(ctx, &state)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	keyID := state.KeyID.ValueString()
+	if keyID == "" {
+		keyID = r.resolveKeyID(ctx, state.Name.ValueString(), resp)
+		if resp.Diagnostics.HasError() {
+			return
+		}
+		if keyID == "" {
+			resp.State.RemoveResource(ctx)
+			return
+		}
+		state.KeyID = types.StringValue(keyID)
+	}
+
+	key, err := r.client.RustClient.DescribeKmsKey(keyID)
+	if err != nil {
+		if strings.Contains(strings.ToLower(err.Error()), "not found") {
+			resp.State.RemoveResource(ctx)
+			return
+		}
+		resp.Diagnostics.AddError(
+			"Error reading KMS key",
+			"Could not read KMS key, unexpected error: "+err.Error(),
+		)
+		return
+	}
+	state.Enabled = types.BoolValue(key.KeyState == "Enabled")
+	state.CreatedAt = types.StringValue(key.CreationDate)
+	resp.Diagnostics.Append(resp.State.Set(ctx, &state)...)
+}
+
+// resolveKeyID maps a key name to its server-side key id by listing the keys
+// when the state does not yet carry one (import path). On the Local dev
+// backend the key id equals the name; on production backends the key created
+// through this provider carries a `name` tag that the listing exposes.
+func (r *kmsKeyRessource) resolveKeyID(ctx context.Context, name string, resp *resource.ReadResponse) string {
+	keys, err := r.client.RustClient.ListKmsKeys()
+	if err != nil {
+		resp.Diagnostics.AddError(
+			"Error listing KMS keys",
+			"Could not resolve key id from name, unexpected error: "+err.Error(),
+		)
+		return ""
+	}
+	for _, key := range keys {
+		if key.KeyID == name || key.Tags["name"] == name {
+			return key.KeyID
+		}
+	}
+	tflog.Warn(ctx, "no KMS key matched name, removing from state", map[string]any{"name": name})
+	return ""
+}
+
+// Update enables or disables the key and updates the Terraform state on success.
+func (r *kmsKeyRessource) Update(ctx context.Context, req resource.UpdateRequest, resp *resource.UpdateResponse) {
+	var plan, state kmsKeyRessourceModel
+	resp.Diagnostics.Append(req.Plan.Get(ctx, &plan)...)
+	resp.Diagnostics.Append(req.State.Get(ctx, &state)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	if !plan.Enabled.Equal(state.Enabled) {
+		keyID := plan.KeyID.ValueString()
+		if keyID == "" {
+			keyID = plan.Name.ValueString()
+		}
+		var err error
+		if plan.Enabled.ValueBool() {
+			err = r.client.RustClient.EnableKmsKey(keyID)
+		} else {
+			err = r.client.RustClient.DisableKmsKey(keyID)
+		}
+		if err != nil {
+			resp.Diagnostics.AddError(
+				"Error updating KMS key",
+				"Could not update KMS key, unexpected error: "+err.Error(),
+			)
+			return
+		}
+	}
+	// Computed-only attributes are carried over from the prior state: the
+	// enable/disable switch does not change the key id or creation date.
+	plan.KeyID = state.KeyID
+	plan.CreatedAt = state.CreatedAt
+	resp.Diagnostics.Append(resp.State.Set(ctx, &plan)...)
+}
+
+// Delete irreversibly deletes the KMS key unless skip_destroy is set.
+func (r *kmsKeyRessource) Delete(ctx context.Context, req resource.DeleteRequest, resp *resource.DeleteResponse) {
+	var state kmsKeyRessourceModel
+	resp.Diagnostics.Append(req.State.Get(ctx, &state)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	if state.SkipDestroy.ValueBool() {
+		tflog.Warn(ctx, "skip_destroy=true: leaving KMS key in place, removing only Terraform state")
+		return
+	}
+
+	keyID := state.KeyID.ValueString()
+	if keyID == "" {
+		keyID = state.Name.ValueString()
+	}
+	if err := r.client.RustClient.DeleteKmsKey(keyID); err != nil {
+		resp.Diagnostics.AddError(
+			"Error deleting KMS key",
+			"Could not delete KMS key, unexpected error: "+err.Error(),
+		)
+	}
+}
+
+func (r *kmsKeyRessource) ImportState(ctx context.Context, req resource.ImportStateRequest, resp *resource.ImportStateResponse) {
+	resource.ImportStatePassthroughID(ctx, path.Root("name"), req, resp)
+}

--- a/provider/rustfs_kms_key_ressource_test.go
+++ b/provider/rustfs_kms_key_ressource_test.go
@@ -1,0 +1,144 @@
+package provider
+
+import (
+	"fmt"
+	"os"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-testing/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/terraform"
+	"github.com/weinmann-emt/terraform-provider-rustfs/pkg/rustfs"
+)
+
+const kmsKeyTestResourceName = "rustfs_kms_key.test"
+
+func TestAccKmsKeyResource(t *testing.T) {
+	name := fmt.Sprintf("tf-kms-key-%d", acctest.RandInt())
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { testAccKmsKeyPreCheck(t) },
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		CheckDestroy:             testAccCheckKmsKeyDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccKmsKeyConfig(name, true),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckKmsKeyExists(name),
+					resource.TestCheckResourceAttr(kmsKeyTestResourceName, "name", name),
+					resource.TestCheckResourceAttr(kmsKeyTestResourceName, "enabled", "true"),
+					resource.TestCheckResourceAttrSet(kmsKeyTestResourceName, "key_id"),
+					resource.TestCheckResourceAttrSet(kmsKeyTestResourceName, "created_at"),
+				),
+			},
+			{
+				Config: testAccKmsKeyConfig(name, false),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckKmsKeyExists(name),
+					resource.TestCheckResourceAttr(kmsKeyTestResourceName, "enabled", "false"),
+				),
+			},
+			{
+				Config: testAccKmsKeyConfig(name, true),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckKmsKeyExists(name),
+					resource.TestCheckResourceAttr(kmsKeyTestResourceName, "enabled", "true"),
+				),
+			},
+			{
+				ResourceName:  kmsKeyTestResourceName,
+				ImportState:   true,
+				ImportStateId: name,
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckKmsKeyExists(name),
+				),
+			},
+		},
+	})
+}
+
+// testAccKmsKeyPreCheck verifies the environment and that the running RustFS
+// backend supports KMS key creation. The Local dev backend does; the Static
+// (read-only) backend does not. When the running backend cannot create keys
+// the whole test skips gracefully instead of failing.
+func testAccKmsKeyPreCheck(t *testing.T) {
+	testAccPreCheck(t)
+
+	client := newKmsKeyAccClient()
+	//#nosec G117 — the probe key name is a public identifier, not a secret
+	probeName := fmt.Sprintf("tf-kms-precheck-%d", acctest.RandInt())
+	probeKey, err := client.CreateKmsKey(probeName)
+	if err != nil {
+		t.Skipf("KMS key creation is not supported on the running backend, skipping: %v", err)
+	}
+	// Clean up the probe key (scheduled deletion; cancellable server-side).
+	if delErr := client.DeleteKmsKey(probeKey.KeyID); delErr != nil {
+		t.Logf("warning: failed to clean up probe key %s: %v", probeKey.KeyID, delErr)
+	}
+}
+
+func testAccKmsKeyConfig(name string, enabled bool) string {
+	return testAccProviderConfig() + fmt.Sprintf(`
+resource "rustfs_kms_key" "test" {
+  name         = %q
+  enabled      = %t
+  skip_destroy = false
+}
+`, name, enabled)
+}
+
+func testAccCheckKmsKeyExists(name string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[kmsKeyTestResourceName]
+		if !ok {
+			return fmt.Errorf("not found: %s", kmsKeyTestResourceName)
+		}
+		if rs.Primary.Attributes["name"] != name {
+			return fmt.Errorf("wrong name in state: %s", rs.Primary.Attributes["name"])
+		}
+		keyID := rs.Primary.Attributes["key_id"]
+		if keyID == "" {
+			return fmt.Errorf("no key_id set in state")
+		}
+
+		key, err := newKmsKeyAccClient().DescribeKmsKey(keyID)
+		if err != nil {
+			return fmt.Errorf("error describing KMS key %s: %s", keyID, err)
+		}
+		if key.KeyID != keyID {
+			return fmt.Errorf("described key id mismatch: got %s, want %s", key.KeyID, keyID)
+		}
+		return nil
+	}
+}
+
+func testAccCheckKmsKeyDestroy(s *terraform.State) error {
+	client := newKmsKeyAccClient()
+	for _, rs := range s.RootModule().Resources {
+		if rs.Type != "rustfs_kms_key" {
+			continue
+		}
+		keyID := rs.Primary.Attributes["key_id"]
+		if keyID == "" {
+			continue
+		}
+		key, err := client.DescribeKmsKey(keyID)
+		if err != nil {
+			// Key gone (or describe refused): that satisfies destruction.
+			continue
+		}
+		if key.KeyState != "PendingDeletion" {
+			return fmt.Errorf("KMS key %s still present in state %s", keyID, key.KeyState)
+		}
+	}
+	return nil
+}
+
+func newKmsKeyAccClient() *rustfs.RustfsAdmin {
+	client := rustfs.New(&rustfs.RustfsAdminConfig{
+		Endpoint:     os.Getenv("RUSTFS_ENDPOINT"),
+		AccessKey:    os.Getenv("RUSTFS_USER"),
+		AccessSecret: os.Getenv("RUSTFS_SECRET"),
+	})
+	return &client
+}


### PR DESCRIPTION
**Issue:** https://github.com/weinmann-emt/terraform-provider-rustfs/issues/123

Add a `rustfs_kms_key` resource for the RustFS KMS key lifecycle (create, describe, enable/disable, rotate).

Closes #123

## Changes
- `pkg/rustfs/kms.go`: client for create/status/list/enable/disable/rotate/delete using the verified wire shapes (`{"tags":{"name":...}}` for create, `{"key_id":...}` bodies).
- `provider/rustfs_kms_key_ressource.go`, registered in `Resources()`. Destroy is gated by a `skip_destroy` safeguard because `kms/keys/delete` is irreversible (Critical route) — the server schedules a cancellable 30-day deletion.
- Unit (httptest) + acceptance tests; docs + example.

## Testing
- `go build`, `go vet`, gofmt clean; golangci-lint no new findings; gosec 0 issues.
- 7/7 httptest unit tests + acceptance (create → disable → re-enable → import) pass against a live RustFS.

## Note
Rotate returns 501 on the Local dev backend — documented; the acceptance test probes and skips gracefully. Full validation of rotate requires a production KMS backend.
