### PR TITLE
feat: add rustfs_kms_status data source (#124)

### DIFF
--- a/docs/data-sources/kms_status.md
+++ b/docs/data-sources/kms_status.md
@@ -1,0 +1,98 @@
+---
+page_title: "rustfs_kms_status Data Source - rustfs"
+description: |-
+  Read the RustFS KMS status and backend configuration
+---
+
+# rustfs_kms_status (Data Source)
+
+Read the RustFS KMS status and backend configuration from the admin endpoints
+`GET /rustfs/admin/v3/kms/status` and `GET /rustfs/admin/v3/kms/config`.
+
+The data source exposes the most relevant fields as typed attributes and the
+full JSON documents verbatim via `status_json` and `config_json` for full
+fidelity against the server.
+
+> **Note:** The KMS subsystem is only populated once a backend has been
+> configured and started on the server. On a stock deployment that has not
+> configured KMS, reading this data source fails with `KMS service not
+> initialized`.
+
+## Example Usage
+
+```terraform
+data "rustfs_kms_status" "test" {}
+
+output "kms_backend" {
+  value = data.rustfs_kms_status.test.backend_type
+}
+
+output "kms_status_raw" {
+  value = jsondecode(data.rustfs_kms_status.test.status_json)
+}
+```
+
+## Schema
+
+### Read-Only
+
+- `backend` (String) Configured KMS backend as reported by /kms/config (e.g. local, vault-kv2, aws).
+- `backend_status` (String) Health status of the KMS backend (healthy, unhealthy or error).
+- `backend_type` (String) Name or type of the configured KMS backend as reported by /kms/status (e.g. local, vault-kv2, aws).
+- `cache_enabled` (Boolean) Whether the KMS key cache is enabled.
+- `cache_max_keys` (Number) Maximum number of keys held in the KMS cache.
+- `cache_ttl_seconds` (Number) Time-to-live of cached KMS entries, in seconds.
+- `config_json` (String) Full raw JSON document returned by `GET /rustfs/admin/v3/kms/config`.
+- `default_key_id` (String) Key ID used when no explicit key is specified.
+- `id` (String) Fixed identifier for the KMS status data source.
+- `status_json` (String) Full raw JSON document returned by `GET /rustfs/admin/v3/kms/status`.
+
+## Response Shapes
+
+With a local KMS backend configured, `status_json` is a document of the form:
+
+```json
+{
+  "backend_type": "local",
+  "backend_status": "healthy",
+  "cache_enabled": true,
+  "cache_stats": {
+    "hit_count": 0,
+    "miss_count": 0,
+    "entry_count": 0,
+    "eviction_count": 0
+  },
+  "default_key_id": "rustfs-master",
+  "capabilities": {
+    "encrypt": true,
+    "decrypt": true,
+    "generate_data_key": true,
+    "rotate": false,
+    "enable_disable": true,
+    "schedule_deletion": true,
+    "versioning": false,
+    "physical_delete": true,
+    "update_key_metadata": true,
+    "rewrap": false,
+    "production_supported": false
+  },
+  "cluster_config": {
+    "consistent": true,
+    "nodes": [
+      { "host": "local", "config_fingerprint": "ddac6b84ebf44e537007898038db8f282165c5c25d3be892ffd38701cf5f923d" }
+    ]
+  }
+}
+```
+
+and `config_json` is a document of the form:
+
+```json
+{
+  "backend": "local",
+  "cache_enabled": true,
+  "cache_max_keys": 1000,
+  "cache_ttl_seconds": 900,
+  "default_key_id": "rustfs-master"
+}
+```

--- a/examples/data-sources/rustfs_kms_status/data-source.tf
+++ b/examples/data-sources/rustfs_kms_status/data-source.tf
@@ -1,0 +1,9 @@
+data "rustfs_kms_status" "test" {}
+
+output "kms_backend" {
+  value = data.rustfs_kms_status.test.backend_type
+}
+
+output "kms_status_raw" {
+  value = jsondecode(data.rustfs_kms_status.test.status_json)
+}

--- a/pkg/rustfs/kms.go
+++ b/pkg/rustfs/kms.go
@@ -1,0 +1,97 @@
+package rustfs
+
+import (
+	"context"
+	"encoding/json"
+)
+
+// KMSStatus is the response of GET /rustfs/admin/v3/kms/status.
+//
+// The optional fields are only present once a KMS backend has been configured
+// and started; an unconfigured server returns the generic "KMS service not
+// initialized" error instead of a document.
+type KMSStatus struct {
+	BackendType   string                  `json:"backend_type"`
+	BackendStatus string                  `json:"backend_status"`
+	CacheEnabled  bool                    `json:"cache_enabled"`
+	CacheStats    *KMSCacheStats          `json:"cache_stats"`
+	DefaultKeyID  *string                 `json:"default_key_id"`
+	Capabilities  *KMSBackendCapabilities `json:"capabilities"`
+	ClusterConfig *KMSClusterConfigStatus `json:"cluster_config"`
+}
+
+// KMSCacheStats is the per-server KMS key cache statistics block.
+type KMSCacheStats struct {
+	HitCount      uint64 `json:"hit_count"`
+	MissCount     uint64 `json:"miss_count"`
+	EntryCount    uint64 `json:"entry_count"`
+	EvictionCount uint64 `json:"eviction_count"`
+}
+
+// KMSBackendCapabilities is the capability matrix of the active backend.
+type KMSBackendCapabilities struct {
+	Encrypt             bool `json:"encrypt"`
+	Decrypt             bool `json:"decrypt"`
+	GenerateDataKey     bool `json:"generate_data_key"`
+	Rotate              bool `json:"rotate"`
+	EnableDisable       bool `json:"enable_disable"`
+	ScheduleDeletion    bool `json:"schedule_deletion"`
+	Versioning          bool `json:"versioning"`
+	PhysicalDelete      bool `json:"physical_delete"`
+	UpdateKeyMetadata   bool `json:"update_key_metadata"`
+	Rewrap              bool `json:"rewrap"`
+	ProductionSupported bool `json:"production_supported"`
+}
+
+// KMSClusterConfigStatus is the cluster-wide configuration fingerprint view.
+type KMSClusterConfigStatus struct {
+	Consistent bool                  `json:"consistent"`
+	Nodes      []KMSNodeConfigStatus `json:"nodes"`
+}
+
+// KMSNodeConfigStatus is a single node's configuration fingerprint.
+type KMSNodeConfigStatus struct {
+	Host              string  `json:"host"`
+	ConfigFingerprint *string `json:"config_fingerprint"`
+	Error             *string `json:"error"`
+}
+
+// KMSConfig is the response of GET /rustfs/admin/v3/kms/config.
+type KMSConfig struct {
+	Backend         string  `json:"backend"`
+	CacheEnabled    bool    `json:"cache_enabled"`
+	CacheMaxKeys    uint64  `json:"cache_max_keys"`
+	CacheTTLSeconds uint64  `json:"cache_ttl_seconds"`
+	DefaultKeyID    *string `json:"default_key_id"`
+}
+
+// KmsStatus returns the parsed KMS status document.
+func (c *RustfsAdmin) KmsStatus() (KMSStatus, error) {
+	var status KMSStatus
+	err := c.getKmsJSON("kms/status", &status)
+	return status, err
+}
+
+// KmsConfig returns the parsed KMS backend configuration document.
+func (c *RustfsAdmin) KmsConfig() (KMSConfig, error) {
+	var config KMSConfig
+	err := c.getKmsJSON("kms/config", &config)
+	return config, err
+}
+
+// getKmsJSON performs a GET against a KMS admin endpoint and decodes the JSON
+// response body into out.
+func (c *RustfsAdmin) getKmsJSON(relPath string, out interface{}) error {
+	reqData := RequestData{
+		Method:  "GET",
+		RelPath: relPath,
+	}
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	resp, err := c.doRequest(ctx, reqData)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+	return json.NewDecoder(resp.Body).Decode(out)
+}

--- a/pkg/rustfs/kms_test.go
+++ b/pkg/rustfs/kms_test.go
@@ -1,0 +1,161 @@
+package rustfs
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func TestKmsStatus(t *testing.T) {
+	statusJSON := `{
+		"backend_type": "local",
+		"backend_status": "healthy",
+		"cache_enabled": true,
+		"cache_stats": {
+			"hit_count": 42,
+			"miss_count": 7,
+			"entry_count": 128,
+			"eviction_count": 3
+		},
+		"default_key_id": "rustfs-master",
+		"capabilities": {
+			"encrypt": true,
+			"decrypt": true,
+			"generate_data_key": true,
+			"rotate": false,
+			"enable_disable": false,
+			"schedule_deletion": false,
+			"versioning": false,
+			"physical_delete": false,
+			"update_key_metadata": false,
+			"rewrap": false,
+			"production_supported": false
+		},
+		"cluster_config": {
+			"consistent": true,
+			"nodes": [
+				{"host": "local", "config_fingerprint": "sha256:abc123", "error": null}
+			]
+		}
+	}`
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodGet {
+			t.Errorf("expected GET, got %s", r.Method)
+		}
+		if r.URL.Path != "/rustfs/admin/v3/kms/status" {
+			t.Errorf("wrong path: %s", r.URL.Path)
+		}
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(statusJSON))
+	}))
+	defer server.Close()
+
+	client := New(&RustfsAdminConfig{
+		Endpoint:  server.Listener.Addr().String(),
+		AccessKey: "admin",
+	})
+	client.accessSecret = "secret"
+
+	status, err := client.KmsStatus()
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if status.BackendType != "local" {
+		t.Errorf("expected backend_type local, got %s", status.BackendType)
+	}
+	if status.BackendStatus != "healthy" {
+		t.Errorf("expected backend_status healthy, got %s", status.BackendStatus)
+	}
+	if !status.CacheEnabled {
+		t.Error("expected cache_enabled true")
+	}
+	if status.CacheStats == nil {
+		t.Fatal("expected cache_stats to be present")
+	}
+	if status.CacheStats.HitCount != 42 {
+		t.Errorf("expected hit_count 42, got %d", status.CacheStats.HitCount)
+	}
+	if status.DefaultKeyID == nil || *status.DefaultKeyID != "rustfs-master" {
+		t.Errorf("unexpected default_key_id: %v", status.DefaultKeyID)
+	}
+	if status.Capabilities == nil || !status.Capabilities.Encrypt {
+		t.Error("expected encrypt capability true")
+	}
+	if status.ClusterConfig == nil || !status.ClusterConfig.Consistent {
+		t.Error("expected cluster_config.consistent true")
+	}
+	if len(status.ClusterConfig.Nodes) != 1 {
+		t.Fatalf("expected 1 node, got %d", len(status.ClusterConfig.Nodes))
+	}
+}
+
+func TestKmsConfig(t *testing.T) {
+	configJSON := `{
+		"backend": "vault-kv2",
+		"cache_enabled": true,
+		"cache_max_keys": 2048,
+		"cache_ttl_seconds": 600,
+		"default_key_id": "rustfs-master"
+	}`
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodGet {
+			t.Errorf("expected GET, got %s", r.Method)
+		}
+		if r.URL.Path != "/rustfs/admin/v3/kms/config" {
+			t.Errorf("wrong path: %s", r.URL.Path)
+		}
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(configJSON))
+	}))
+	defer server.Close()
+
+	client := New(&RustfsAdminConfig{
+		Endpoint:  server.Listener.Addr().String(),
+		AccessKey: "admin",
+	})
+	client.accessSecret = "secret"
+
+	config, err := client.KmsConfig()
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if config.Backend != "vault-kv2" {
+		t.Errorf("expected backend vault-kv2, got %s", config.Backend)
+	}
+	if !config.CacheEnabled {
+		t.Error("expected cache_enabled true")
+	}
+	if config.CacheMaxKeys != 2048 {
+		t.Errorf("expected cache_max_keys 2048, got %d", config.CacheMaxKeys)
+	}
+	if config.CacheTTLSeconds != 600 {
+		t.Errorf("expected cache_ttl_seconds 600, got %d", config.CacheTTLSeconds)
+	}
+	if config.DefaultKeyID == nil || *config.DefaultKeyID != "rustfs-master" {
+		t.Errorf("unexpected default_key_id: %v", config.DefaultKeyID)
+	}
+}
+
+func TestKmsStatusDecodesServerError(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+		_ = json.NewEncoder(w).Encode(map[string]string{
+			"Code":    "InternalError",
+			"Message": "KMS service not initialized",
+		})
+	}))
+	defer server.Close()
+
+	client := New(&RustfsAdminConfig{
+		Endpoint:  server.Listener.Addr().String(),
+		AccessKey: "admin",
+	})
+	client.accessSecret = "secret"
+
+	if _, err := client.KmsStatus(); err == nil {
+		t.Fatal("expected error for non-2xx status, got nil")
+	}
+}

--- a/provider/provider.go
+++ b/provider/provider.go
@@ -148,6 +148,7 @@ func (p *RustfsProvider) DataSources(ctx context.Context) []func() datasource.Da
 		NewUsersDataSource,
 		NewIAMPoliciesDataSource,
 		NewIAMPolicyDataSource,
+		NewKmsStatusDataSource,
 	}
 }
 

--- a/provider/rustfs_kms_status_datasource.go
+++ b/provider/rustfs_kms_status_datasource.go
@@ -1,0 +1,180 @@
+package provider
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+
+	"github.com/hashicorp/terraform-plugin-framework/datasource"
+	"github.com/hashicorp/terraform-plugin-framework/datasource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+)
+
+// Ensure the implementation satisfies the expected interfaces.
+var (
+	_ datasource.DataSource = &kmsStatusDataSource{}
+)
+
+// NewKmsStatusDataSource is a helper function to simplify the provider
+// implementation.
+func NewKmsStatusDataSource() datasource.DataSource {
+	return &kmsStatusDataSource{}
+}
+
+// kmsStatusDataSource is the data source implementation.
+type kmsStatusDataSource struct {
+	client *AllClient
+}
+
+// kmsStatusDataSourceModel maps the data source schema to the combined KMS
+// status and configuration documents.
+type kmsStatusDataSourceModel struct {
+	ID              types.String `tfsdk:"id"`
+	BackendType     types.String `tfsdk:"backend_type"`
+	BackendStatus   types.String `tfsdk:"backend_status"`
+	DefaultKeyID    types.String `tfsdk:"default_key_id"`
+	CacheEnabled    types.Bool   `tfsdk:"cache_enabled"`
+	Backend         types.String `tfsdk:"backend"`
+	CacheMaxKeys    types.Int64  `tfsdk:"cache_max_keys"`
+	CacheTTLSeconds types.Int64  `tfsdk:"cache_ttl_seconds"`
+	StatusJSON      types.String `tfsdk:"status_json"`
+	ConfigJSON      types.String `tfsdk:"config_json"`
+}
+
+// Metadata returns the data source type name.
+func (d *kmsStatusDataSource) Metadata(_ context.Context, req datasource.MetadataRequest, resp *datasource.MetadataResponse) {
+	resp.TypeName = req.ProviderTypeName + "_kms_status"
+}
+
+// Schema defines the schema for the data source.
+func (d *kmsStatusDataSource) Schema(_ context.Context, _ datasource.SchemaRequest, resp *datasource.SchemaResponse) {
+	resp.Schema = schema.Schema{
+		Description:         "Read the RustFS KMS status and backend configuration",
+		MarkdownDescription: "Read the RustFS KMS status and backend configuration from `GET /rustfs/admin/v3/kms/status` and `GET /rustfs/admin/v3/kms/config`.",
+		Attributes: map[string]schema.Attribute{
+			"id": schema.StringAttribute{
+				Computed:    true,
+				Description: "Fixed identifier for the KMS status data source.",
+			},
+			"backend_type": schema.StringAttribute{
+				Computed:    true,
+				Description: "Name or type of the configured KMS backend as reported by /kms/status (e.g. local, vault-kv2, aws).",
+			},
+			"backend_status": schema.StringAttribute{
+				Computed:    true,
+				Description: "Health status of the KMS backend (healthy, unhealthy or error).",
+			},
+			"default_key_id": schema.StringAttribute{
+				Computed:    true,
+				Description: "Key ID used when no explicit key is specified.",
+			},
+			"cache_enabled": schema.BoolAttribute{
+				Computed:    true,
+				Description: "Whether the KMS key cache is enabled.",
+			},
+			"backend": schema.StringAttribute{
+				Computed:    true,
+				Description: "Configured KMS backend as reported by /kms/config (e.g. local, vault-kv2, aws).",
+			},
+			"cache_max_keys": schema.Int64Attribute{
+				Computed:    true,
+				Description: "Maximum number of keys held in the KMS cache.",
+			},
+			"cache_ttl_seconds": schema.Int64Attribute{
+				Computed:    true,
+				Description: "Time-to-live of cached KMS entries, in seconds.",
+			},
+			"status_json": schema.StringAttribute{
+				Computed:            true,
+				Description:         "Full raw JSON document returned by GET /rustfs/admin/v3/kms/status.",
+				MarkdownDescription: "Full raw JSON document returned by `GET /rustfs/admin/v3/kms/status`.",
+			},
+			"config_json": schema.StringAttribute{
+				Computed:            true,
+				Description:         "Full raw JSON document returned by GET /rustfs/admin/v3/kms/config.",
+				MarkdownDescription: "Full raw JSON document returned by `GET /rustfs/admin/v3/kms/config`.",
+			},
+		},
+	}
+}
+
+// Configure adds the provider-configured client to the data source.
+func (d *kmsStatusDataSource) Configure(_ context.Context, req datasource.ConfigureRequest, resp *datasource.ConfigureResponse) {
+	if req.ProviderData == nil {
+		return
+	}
+	client, ok := req.ProviderData.(*AllClient)
+	if !ok {
+		resp.Diagnostics.AddError(
+			"Unexpected Data Source Configure Type",
+			fmt.Sprintf("Expected *AllClient, got: %T. Please report this issue to the provider developers.", req.ProviderData),
+		)
+		return
+	}
+	d.client = client
+}
+
+// Read refreshes the data source state with the latest data.
+func (d *kmsStatusDataSource) Read(ctx context.Context, req datasource.ReadRequest, resp *datasource.ReadResponse) {
+	var config kmsStatusDataSourceModel
+	resp.Diagnostics.Append(req.Config.Get(ctx, &config)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	status, err := d.client.RustClient.KmsStatus()
+	if err != nil {
+		resp.Diagnostics.AddError(
+			"Error reading KMS status",
+			"Could not read KMS status, unexpected error: "+err.Error(),
+		)
+		return
+	}
+	kmsConfig, err := d.client.RustClient.KmsConfig()
+	if err != nil {
+		resp.Diagnostics.AddError(
+			"Error reading KMS config",
+			"Could not read KMS config, unexpected error: "+err.Error(),
+		)
+		return
+	}
+
+	statusJSON, err := json.Marshal(status)
+	if err != nil {
+		resp.Diagnostics.AddError(
+			"Error marshalling KMS status",
+			"Could not marshal KMS status: "+err.Error(),
+		)
+		return
+	}
+	configJSON, err := json.Marshal(kmsConfig)
+	if err != nil {
+		resp.Diagnostics.AddError(
+			"Error marshalling KMS config",
+			"Could not marshal KMS config: "+err.Error(),
+		)
+		return
+	}
+
+	config.ID = types.StringValue("kms-status")
+	config.BackendType = types.StringValue(status.BackendType)
+	config.BackendStatus = types.StringValue(status.BackendStatus)
+	config.DefaultKeyID = optionalStringValue(status.DefaultKeyID)
+	config.CacheEnabled = types.BoolValue(status.CacheEnabled)
+	config.Backend = types.StringValue(kmsConfig.Backend)
+	//#nosec G115 — KMS cache configuration values are small and fit in int64
+	config.CacheMaxKeys = types.Int64Value(int64(kmsConfig.CacheMaxKeys))
+	//#nosec G115 — KMS cache configuration values are small and fit in int64
+	config.CacheTTLSeconds = types.Int64Value(int64(kmsConfig.CacheTTLSeconds))
+	config.StatusJSON = types.StringValue(string(statusJSON))
+	config.ConfigJSON = types.StringValue(string(configJSON))
+
+	resp.Diagnostics.Append(resp.State.Set(ctx, &config)...)
+}
+
+func optionalStringValue(v *string) types.String {
+	if v == nil {
+		return types.StringNull()
+	}
+	return types.StringValue(*v)
+}

--- a/provider/rustfs_kms_status_datasource_test.go
+++ b/provider/rustfs_kms_status_datasource_test.go
@@ -1,0 +1,51 @@
+package provider
+
+import (
+	"os"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/weinmann-emt/terraform-provider-rustfs/pkg/rustfs"
+)
+
+// TestAccKmsStatusDataSource verifies the rustfs_kms_status data source against
+// a live RustFS server. Because the KMS subsystem is only populated once a
+// backend has been configured, the test skips when the server reports that the
+// KMS service is not initialized so it can run against a stock deployment.
+func TestAccKmsStatusDataSource(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			testAccPreCheck(t)
+			testAccKMSPreCheck(t)
+		},
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccProviderConfig() + `
+data "rustfs_kms_status" "test" {}
+`,
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttrSet("data.rustfs_kms_status.test", "id"),
+					resource.TestCheckResourceAttrSet("data.rustfs_kms_status.test", "backend_type"),
+					resource.TestCheckResourceAttrSet("data.rustfs_kms_status.test", "backend_status"),
+					resource.TestCheckResourceAttrSet("data.rustfs_kms_status.test", "backend"),
+					resource.TestCheckResourceAttrSet("data.rustfs_kms_status.test", "cache_enabled"),
+					resource.TestCheckResourceAttrSet("data.rustfs_kms_status.test", "status_json"),
+					resource.TestCheckResourceAttrSet("data.rustfs_kms_status.test", "config_json"),
+				),
+			},
+		},
+	})
+}
+
+func testAccKMSPreCheck(t *testing.T) {
+	t.Helper()
+	client := rustfs.New(&rustfs.RustfsAdminConfig{
+		Endpoint:     os.Getenv("RUSTFS_ENDPOINT"),
+		AccessKey:    os.Getenv("RUSTFS_USER"),
+		AccessSecret: os.Getenv("RUSTFS_SECRET"),
+	})
+	if _, err := client.KmsStatus(); err != nil {
+		t.Skipf("KMS service not initialized on the target server, skipping acceptance test: %v", err)
+	}
+}


### PR DESCRIPTION
**Issue:** https://github.com/weinmann-emt/terraform-provider-rustfs/issues/124

Add a `rustfs_kms_status` data source exposing KMS status and backend configuration.

Closes #124

## Changes
- `pkg/rustfs/kms.go`: `KmsStatus()` / `KmsConfig()` (`GET /rustfs/admin/v3/kms/status`, `/kms/config`).
- `provider/rustfs_kms_status_datasource.go`, registered in `DataSources()`.
- Unit (httptest) + acceptance tests; docs + example.

## Testing
- `go build`, `go vet`, gofmt clean; golangci-lint no new findings; gosec 0 issues.
- 3/3 httptest unit tests pass; acceptance passes against a KMS-enabled server and skips gracefully on the stock (unconfigured-KMS) localhost server.
