### PR TITLE
feat: add rustfs_module_switch resource (#119)

### DIFF
--- a/docs/resources/module_switch.md
+++ b/docs/resources/module_switch.md
@@ -1,0 +1,48 @@
+---
+page_title: "rustfs_module_switch Resource - rustfs"
+description: |-
+  Manage RustFS feature module switches
+---
+
+# rustfs_module_switch (Resource)
+
+Manage RustFS feature module switches (the notify and audit modules).
+
+The server exposes two writable module switches — `notify_enabled` and
+`audit_enabled` — together with read-only state describing the persisted
+values and their source. This resource writes the full set of switches on
+every apply. Destroying this resource leaves the server switches unchanged
+(the admin API has no DELETE/reset endpoint for module switches).
+
+The effective switch state may be overridden by the `RUSTFS_NOTIFY_ENABLE` /
+`RUSTFS_AUDIT_ENABLE` environment variables on the server. When such an
+override is present, the server rejects conflicting writes; update the
+environment value first, then apply the switch state.
+
+## Example Usage
+
+```terraform
+resource "rustfs_module_switch" "test" {
+  notify_enabled = true
+  audit_enabled  = true
+}
+```
+
+## Schema
+
+### Optional
+
+- `audit_enabled` (Boolean) Whether the audit module is enabled. Defaults to `false`.
+- `notify_enabled` (Boolean) Whether the notify module is enabled. Defaults to `true`.
+
+### Read-Only
+
+- `id` (String) Fixed identifier for the module switch set.
+
+## Import
+
+Import is supported using the fixed id `module-switches`:
+
+```
+terraform import rustfs_module_switch.test module-switches
+```

--- a/examples/resources/rustfs_module_switch/resource.tf
+++ b/examples/resources/rustfs_module_switch/resource.tf
@@ -1,0 +1,4 @@
+resource "rustfs_module_switch" "test" {
+  notify_enabled = true
+  audit_enabled  = true
+}

--- a/pkg/rustfs/module_switch.go
+++ b/pkg/rustfs/module_switch.go
@@ -1,0 +1,86 @@
+package rustfs
+
+import (
+	"context"
+	"encoding/json"
+)
+
+// ModuleSwitchSource indicates where the effective module switch state came from.
+// Values mirror the server's serialization: "env", "console", or "default".
+type ModuleSwitchSource string
+
+const (
+	ModuleSwitchSourceEnv     ModuleSwitchSource = "env"
+	ModuleSwitchSourceConsole ModuleSwitchSource = "console"
+	ModuleSwitchSourceDefault ModuleSwitchSource = "default"
+)
+
+// ModuleSwitchState is the full server representation of the feature module
+// switches. NotifyEnabled and AuditEnabled are the writable toggles; the
+// remaining fields are read-only and describe the persisted state, the source
+// of the effective value, and the admin discovery routes.
+type ModuleSwitchState struct {
+	NotifyEnabled bool `json:"notify_enabled"`
+	AuditEnabled  bool `json:"audit_enabled"`
+	// Read-only fields reported by GET.
+	PersistedNotifyEnabled bool                   `json:"persisted_notify_enabled,omitempty"`
+	PersistedAuditEnabled  bool                   `json:"persisted_audit_enabled,omitempty"`
+	NotifySource           ModuleSwitchSource     `json:"notify_source,omitempty"`
+	AuditSource            ModuleSwitchSource     `json:"audit_source,omitempty"`
+	AdminDiscovery         *ModuleSwitchDiscovery `json:"admin_discovery,omitempty"`
+}
+
+// ModuleSwitchDiscovery holds the admin discovery routes exposed by the server.
+type ModuleSwitchDiscovery struct {
+	RuntimeCapabilities string `json:"runtimeCapabilities"`
+	ClusterSnapshot     string `json:"clusterSnapshot"`
+	ExtensionsCatalog   string `json:"extensionsCatalog"`
+}
+
+// ModuleSwitchUpdate is the request body for PUT /module-switches.
+type ModuleSwitchUpdate struct {
+	NotifyEnabled bool `json:"notify_enabled"`
+	AuditEnabled  bool `json:"audit_enabled"`
+}
+
+// GetModuleSwitches reads the current feature module switches from the server.
+func (c *RustfsAdmin) GetModuleSwitches() (*ModuleSwitchState, error) {
+	reqData := RequestData{
+		Method:  "GET",
+		RelPath: "module-switches",
+	}
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	resp, err := c.doRequest(ctx, reqData)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+	state := &ModuleSwitchState{}
+	err = json.NewDecoder(resp.Body).Decode(state)
+	return state, err
+}
+
+// SetModuleSwitches applies the feature module switch toggles. The server
+// returns the resulting state after applying the update.
+func (c *RustfsAdmin) SetModuleSwitches(update ModuleSwitchUpdate) (*ModuleSwitchState, error) {
+	bytes, err := json.Marshal(update)
+	if err != nil {
+		return nil, err
+	}
+	reqData := RequestData{
+		Method:  "PUT",
+		RelPath: "module-switches",
+		Content: bytes,
+	}
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	resp, err := c.doRequest(ctx, reqData)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+	state := &ModuleSwitchState{}
+	err = json.NewDecoder(resp.Body).Decode(state)
+	return state, err
+}

--- a/pkg/rustfs/module_switch_test.go
+++ b/pkg/rustfs/module_switch_test.go
@@ -1,0 +1,82 @@
+package rustfs
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+func newModuleSwitchTestServer(t *testing.T, handler http.HandlerFunc) *RustfsAdmin {
+	t.Helper()
+	srv := httptest.NewServer(handler)
+	t.Cleanup(srv.Close)
+	c := New(&RustfsAdminConfig{
+		AccessKey:    "admin",
+		AccessSecret: "secret",
+		Endpoint:     strings.TrimPrefix(srv.URL, "http://"),
+	})
+	return &c
+}
+
+func TestGetModuleSwitches(t *testing.T) {
+	client := newModuleSwitchTestServer(t, func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodGet {
+			t.Errorf("expected GET, got %s", r.Method)
+		}
+		if r.URL.Path != "/rustfs/admin/v3/module-switches" {
+			t.Errorf("wrong path: %s", r.URL.Path)
+		}
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"notify_enabled":true,"audit_enabled":false,"persisted_notify_enabled":true,"persisted_audit_enabled":false,"notify_source":"console","audit_source":"console","admin_discovery":{"runtimeCapabilities":"/x","clusterSnapshot":"/y","extensionsCatalog":"/z"}}`))
+	})
+	state, err := client.GetModuleSwitches()
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !state.NotifyEnabled {
+		t.Errorf("expected notify_enabled true, got %v", state.NotifyEnabled)
+	}
+	if state.AuditEnabled {
+		t.Errorf("expected audit_enabled false, got %v", state.AuditEnabled)
+	}
+	if state.NotifySource != ModuleSwitchSourceConsole {
+		t.Errorf("expected notify_source console, got %q", state.NotifySource)
+	}
+	if state.AdminDiscovery == nil || state.AdminDiscovery.RuntimeCapabilities != "/x" {
+		t.Errorf("expected admin_discovery.runtimeCapabilities /x, got %+v", state.AdminDiscovery)
+	}
+}
+
+func TestSetModuleSwitches(t *testing.T) {
+	var called bool
+	client := newModuleSwitchTestServer(t, func(w http.ResponseWriter, r *http.Request) {
+		called = true
+		if r.Method != http.MethodPut {
+			t.Errorf("expected PUT, got %s", r.Method)
+		}
+		if r.URL.Path != "/rustfs/admin/v3/module-switches" {
+			t.Errorf("wrong path: %s", r.URL.Path)
+		}
+		var body ModuleSwitchUpdate
+		if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+			t.Errorf("invalid body: %v", err)
+		}
+		if !body.NotifyEnabled || body.AuditEnabled {
+			t.Errorf("wrong body: %+v", body)
+		}
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"notify_enabled":true,"audit_enabled":false,"persisted_notify_enabled":true,"persisted_audit_enabled":false,"notify_source":"console","audit_source":"console"}`))
+	})
+	state, err := client.SetModuleSwitches(ModuleSwitchUpdate{NotifyEnabled: true, AuditEnabled: false})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !called {
+		t.Fatal("handler was not invoked")
+	}
+	if !state.NotifyEnabled {
+		t.Errorf("expected returned notify_enabled true, got %v", state.NotifyEnabled)
+	}
+}

--- a/provider/provider.go
+++ b/provider/provider.go
@@ -137,6 +137,7 @@ func (p *RustfsProvider) Resources(ctx context.Context) []func() resource.Resour
 		NewBucketReplicationResource,
 		NewBucketEncryptionResource,
 		NewBucketVersioningResource,
+		NewModuleSwitchRessource,
 	}
 }
 

--- a/provider/rustfs_module_switch_ressource.go
+++ b/provider/rustfs_module_switch_ressource.go
@@ -1,0 +1,151 @@
+package provider
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/hashicorp/terraform-plugin-framework/path"
+	"github.com/hashicorp/terraform-plugin-framework/resource"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/booldefault"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/hashicorp/terraform-plugin-log/tflog"
+	"github.com/weinmann-emt/terraform-provider-rustfs/pkg/rustfs"
+)
+
+var (
+	_ resource.Resource                = &ModuleSwitchRessource{}
+	_ resource.ResourceWithImportState = &ModuleSwitchRessource{}
+)
+
+type ModuleSwitchRessource struct {
+	client *AllClient
+}
+
+type ModuleSwitchRessourceModel struct {
+	ID            types.String `tfsdk:"id"`
+	NotifyEnabled types.Bool   `tfsdk:"notify_enabled"`
+	AuditEnabled  types.Bool   `tfsdk:"audit_enabled"`
+}
+
+func NewModuleSwitchRessource() resource.Resource {
+	return &ModuleSwitchRessource{}
+}
+
+func (r *ModuleSwitchRessource) Metadata(_ context.Context, req resource.MetadataRequest, resp *resource.MetadataResponse) {
+	resp.TypeName = req.ProviderTypeName + "_module_switch"
+}
+
+func (r *ModuleSwitchRessource) Schema(_ context.Context, _ resource.SchemaRequest, resp *resource.SchemaResponse) {
+	resp.Schema = schema.Schema{
+		Description:         "Manage RustFS feature module switches",
+		MarkdownDescription: "Manage RustFS feature module switches (notify and audit modules).",
+		Attributes: map[string]schema.Attribute{
+			"id": schema.StringAttribute{
+				Computed:    true,
+				Description: "Fixed identifier for the module switch set.",
+			},
+			"notify_enabled": schema.BoolAttribute{
+				Optional:    true,
+				Computed:    true,
+				Default:     booldefault.StaticBool(true),
+				Description: "Whether the notify module is enabled.",
+			},
+			"audit_enabled": schema.BoolAttribute{
+				Optional:    true,
+				Computed:    true,
+				Default:     booldefault.StaticBool(false),
+				Description: "Whether the audit module is enabled.",
+			},
+		},
+	}
+}
+
+func (r *ModuleSwitchRessource) Configure(_ context.Context, req resource.ConfigureRequest, resp *resource.ConfigureResponse) {
+	if req.ProviderData == nil {
+		return
+	}
+	client, ok := req.ProviderData.(*AllClient)
+	if !ok {
+		resp.Diagnostics.AddError("Unexpected Resource Configure Type", fmt.Sprintf("Expected *AllClient, got: %T.", req.ProviderData))
+		return
+	}
+	r.client = client
+}
+
+func (r *ModuleSwitchRessource) Create(ctx context.Context, req resource.CreateRequest, resp *resource.CreateResponse) {
+	var plan ModuleSwitchRessourceModel
+	resp.Diagnostics.Append(req.Plan.Get(ctx, &plan)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	state, err := r.client.RustClient.SetModuleSwitches(moduleSwitchUpdateFromModel(plan))
+	if err != nil {
+		resp.Diagnostics.AddError("Error setting module switches", "Could not set module switches: "+err.Error())
+		return
+	}
+
+	tflog.Trace(ctx, "created module switches")
+	plan.ID = types.StringValue("module-switches")
+	applyModuleSwitchState(&plan, state)
+	resp.Diagnostics.Append(resp.State.Set(ctx, &plan)...)
+}
+
+func (r *ModuleSwitchRessource) Read(ctx context.Context, req resource.ReadRequest, resp *resource.ReadResponse) {
+	var state ModuleSwitchRessourceModel
+	resp.Diagnostics.Append(req.State.Get(ctx, &state)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	switches, err := r.client.RustClient.GetModuleSwitches()
+	if err != nil {
+		resp.Diagnostics.AddError("Error reading module switches", "Could not read module switches: "+err.Error())
+		return
+	}
+
+	applyModuleSwitchState(&state, switches)
+	resp.Diagnostics.Append(resp.State.Set(ctx, &state)...)
+}
+
+func (r *ModuleSwitchRessource) Update(ctx context.Context, req resource.UpdateRequest, resp *resource.UpdateResponse) {
+	var plan ModuleSwitchRessourceModel
+	resp.Diagnostics.Append(req.Plan.Get(ctx, &plan)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	state, err := r.client.RustClient.SetModuleSwitches(moduleSwitchUpdateFromModel(plan))
+	if err != nil {
+		resp.Diagnostics.AddError("Error updating module switches", "Could not update module switches: "+err.Error())
+		return
+	}
+
+	plan.ID = types.StringValue("module-switches")
+	applyModuleSwitchState(&plan, state)
+	resp.Diagnostics.Append(resp.State.Set(ctx, &plan)...)
+}
+
+// Delete removes the resource from state. The admin API exposes no reset
+// endpoint for module switches, so the server switches are intentionally left
+// unchanged on destroy.
+func (r *ModuleSwitchRessource) Delete(ctx context.Context, req resource.DeleteRequest, resp *resource.DeleteResponse) {
+	tflog.Trace(ctx, "module switches left unchanged on destroy (no DELETE endpoint)")
+}
+
+func (r *ModuleSwitchRessource) ImportState(ctx context.Context, req resource.ImportStateRequest, resp *resource.ImportStateResponse) {
+	resource.ImportStatePassthroughID(ctx, path.Root("id"), req, resp)
+}
+
+func moduleSwitchUpdateFromModel(model ModuleSwitchRessourceModel) rustfs.ModuleSwitchUpdate {
+	return rustfs.ModuleSwitchUpdate{
+		NotifyEnabled: model.NotifyEnabled.ValueBool(),
+		AuditEnabled:  model.AuditEnabled.ValueBool(),
+	}
+}
+
+func applyModuleSwitchState(model *ModuleSwitchRessourceModel, state *rustfs.ModuleSwitchState) {
+	model.NotifyEnabled = types.BoolValue(state.NotifyEnabled)
+	model.AuditEnabled = types.BoolValue(state.AuditEnabled)
+}

--- a/provider/rustfs_module_switch_ressource_test.go
+++ b/provider/rustfs_module_switch_ressource_test.go
@@ -1,0 +1,106 @@
+package provider
+
+import (
+	"context"
+	"os"
+	"testing"
+
+	fwresource "github.com/hashicorp/terraform-plugin-framework/resource"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/weinmann-emt/terraform-provider-rustfs/pkg/rustfs"
+) // originalModuleSwitch captures the server's module switch state before the
+// test mutates it, so the test can restore the original state afterwards.
+var originalModuleSwitch *rustfs.ModuleSwitchState
+
+func readModuleSwitchState(t *testing.T) *rustfs.ModuleSwitchState {
+	t.Helper()
+	client := rustfs.New(&rustfs.RustfsAdminConfig{
+		AccessKey:    os.Getenv("RUSTFS_USER"),
+		AccessSecret: os.Getenv("RUSTFS_SECRET"),
+		Endpoint:     os.Getenv("RUSTFS_ENDPOINT"),
+	})
+	state, err := client.GetModuleSwitches()
+	if err != nil {
+		t.Fatalf("failed to read original module switches: %v", err)
+	}
+	return state
+}
+
+func TestAccModuleSwitchResource(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		PreCheck: func() {
+			testAccPreCheck(t)
+			originalModuleSwitch = readModuleSwitchState(t)
+			t.Cleanup(func() {
+				client := rustfs.New(&rustfs.RustfsAdminConfig{
+					AccessKey:    os.Getenv("RUSTFS_USER"),
+					AccessSecret: os.Getenv("RUSTFS_SECRET"),
+					Endpoint:     os.Getenv("RUSTFS_ENDPOINT"),
+				})
+				update := rustfs.ModuleSwitchUpdate{
+					NotifyEnabled: originalModuleSwitch.NotifyEnabled,
+					AuditEnabled:  originalModuleSwitch.AuditEnabled,
+				}
+				if _, err := client.SetModuleSwitches(update); err != nil {
+					t.Errorf("failed to restore original module switches: %v", err)
+				}
+			})
+		},
+		Steps: []resource.TestStep{
+			{
+				Config: testAccProviderConfig() + `
+resource "rustfs_module_switch" "test" {
+  notify_enabled = true
+  audit_enabled  = true
+}
+`,
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr("rustfs_module_switch.test", "id", "module-switches"),
+					resource.TestCheckResourceAttr("rustfs_module_switch.test", "notify_enabled", "true"),
+					resource.TestCheckResourceAttr("rustfs_module_switch.test", "audit_enabled", "true"),
+				),
+			},
+			{
+				Config: testAccProviderConfig() + `
+resource "rustfs_module_switch" "test" {
+  notify_enabled = false
+  audit_enabled  = true
+}
+`,
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr("rustfs_module_switch.test", "notify_enabled", "false"),
+					resource.TestCheckResourceAttr("rustfs_module_switch.test", "audit_enabled", "true"),
+				),
+			},
+		},
+	})
+}
+
+func TestModuleSwitchResourceSchema(t *testing.T) {
+	r := NewModuleSwitchRessource()
+	resp := &fwresource.SchemaResponse{}
+	r.Schema(context.TODO(), fwresource.SchemaRequest{}, resp)
+
+	if diags := resp.Diagnostics; diags.HasError() {
+		t.Fatalf("schema diagnostics: %v", diags)
+	}
+
+	attrs := resp.Schema.GetAttributes()
+	for _, name := range []string{"id", "notify_enabled", "audit_enabled"} {
+		if _, ok := attrs[name]; !ok {
+			t.Errorf("expected %s attribute", name)
+		}
+	}
+}
+
+func TestModuleSwitchUpdateFromModel(t *testing.T) {
+	update := moduleSwitchUpdateFromModel(ModuleSwitchRessourceModel{
+		NotifyEnabled: types.BoolValue(true),
+		AuditEnabled:  types.BoolValue(false),
+	})
+	if !update.NotifyEnabled || update.AuditEnabled {
+		t.Fatalf("unexpected update: %+v", update)
+	}
+}


### PR DESCRIPTION
**Issue:** https://github.com/weinmann-emt/terraform-provider-rustfs/issues/119

Add a `rustfs_module_switch` resource to manage the server feature module switches.

Closes #119

## Changes
- `pkg/rustfs/module_switch.go`: get/set client for `GET`/`PUT /rustfs/admin/v3/module-switches`.
- `provider/rustfs_module_switch_ressource.go` (`notify_enabled` + `audit_enabled` attributes, full-set PUT), registered in `Resources()`.
- Unit (httptest) + acceptance tests; docs + example.

## Testing
- `go build`, `go vet`, gofmt clean; golangci-lint no new findings; gosec 0 issues.
- Unit tests + `TestAccModuleSwitchResource` pass against a live RustFS (original state restored via `t.Cleanup`).

## Note
Verified against RustFS source + live server: the module-switch payload is a fixed two-toggle struct (`notify_enabled`/`audit_enabled`), not the `map[string]bool` shape the plan assumed. Both switches are always written via a full-set PUT; there is no reset endpoint, so Delete is a no-op.
