### PR TITLE
feat: add rustfs_audit_target resource (#120)

### DIFF
--- a/docs/resources/audit_target.md
+++ b/docs/resources/audit_target.md
@@ -1,0 +1,79 @@
+---
+page_title: "rustfs_audit_target Resource - rustfs"
+description: |-
+  Manage RustFS audit-log webhook/HTTP targets
+---
+
+# rustfs_audit_target (Resource)
+
+Manage RustFS audit-log webhook/HTTP targets.
+
+The audit target is addressed by its `target_type` (the audit subsystem, e.g.
+`audit_webhook`) and `target_name`. Destroying this resource resets the target
+to its default configuration via the admin `reset` endpoint (the admin API has
+no plain delete for targets).
+
+The admin list endpoint returns only identity and runtime health metadata for
+each target; it does not echo the configured values (endpoint, auth token,
+comment, ...). Config fields are therefore preserved by the provider and are
+never refreshed from the server on read. `auth_token` is sensitive and never
+logged.
+
+## Example Usage
+
+```terraform
+resource "rustfs_audit_target" "test" {
+  target_type = "audit_webhook"
+  target_name = "terraform"
+  endpoint    = "https://hooks.example.com/webhook/terraform"
+  auth_token  = "superSecret"
+  comment     = "managed by terraform"
+}
+```
+
+## Schema
+
+### Required
+
+- `target_name` (String) Name of the audit target. Changing this forces recreation.
+
+### Optional
+
+- `target_type` (String) Audit target subsystem. Defaults to `audit_webhook`. Valid values: `audit_webhook`, `audit_kafka`, `audit_amqp`, `audit_mqtt`, `audit_mysql`, `audit_nats`, `audit_postgres`, `audit_pulsar`, `audit_redis`.
+- `endpoint` (String) Endpoint URL the audit target posts to (webhook).
+- `auth_token` (String, Sensitive) Optional bearer token for the audit target (webhook). Not refreshed from the server on read.
+- `comment` (String) Optional comment describing the audit target.
+- `queue_limit` (Number) Optional in-memory queue limit for the audit target.
+- `queue_dir` (String) Optional absolute path of the on-disk queue directory for the audit target.
+- `client_cert` (String, Sensitive) Optional client certificate for mTLS to the audit target.
+- `client_key` (String, Sensitive) Optional client private key for mTLS to the audit target.
+- `client_ca` (String, Sensitive) Optional CA certificate used to verify the audit target.
+- `skip_tls_verify` (Boolean) Skip TLS certificate verification for the audit target. Defaults to `false`.
+
+### Read-Only
+
+- `health_state` (String) Runtime health state of the audit target (offline/online/...).
+- `health_reason` (String) Runtime health reason for the audit target.
+- `status` (String) Runtime status of the audit target.
+
+## Notes
+
+The RustFS audit module must be enabled on the server (set
+`RUSTFS_AUDIT_ENABLE=true` or enable it from the console) before audit targets
+can be managed; otherwise the admin API rejects target operations. Webhook
+endpoints must also be allowed by the server's outbound policy
+(`RUSTFS_OUTBOUND_ALLOW_ORIGINS`) — loopback/private addresses are rejected by
+default.
+
+## Import
+
+Import is supported using the `<target_type>/<target_name>` pair:
+
+```
+terraform import rustfs_audit_target.test audit_webhook/terraform
+```
+
+Because the admin list endpoint does not echo target configuration values, only
+`target_type` and `target_name` are populated on import; config attributes
+(`endpoint`, `auth_token`, `comment`, ...) must be set in configuration after
+import.

--- a/examples/resources/rustfs_audit_target/resource.tf
+++ b/examples/resources/rustfs_audit_target/resource.tf
@@ -1,0 +1,7 @@
+resource "rustfs_audit_target" "test" {
+  target_type = "audit_webhook"
+  target_name = "terraform"
+  endpoint    = "https://hooks.example.com/webhook/terraform"
+  auth_token  = "superSecret"
+  comment     = "managed by terraform"
+}

--- a/pkg/rustfs/audit_target.go
+++ b/pkg/rustfs/audit_target.go
@@ -1,0 +1,101 @@
+package rustfs
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+)
+
+// AuditTargetKeyValue is a single key/value pair in an audit target config.
+type AuditTargetKeyValue struct {
+	Key   string `json:"key"`
+	Value string `json:"value"`
+}
+
+// AuditTarget describes an audit-log target as returned by the admin list
+// endpoint. The admin list response does not echo the target configuration
+// (endpoint, auth token, ...) — only identity and runtime health metadata, so
+// those config fields must be preserved by the caller rather than read back.
+type AuditTarget struct {
+	AccountID    string `json:"account_id"`
+	Service      string `json:"service"`
+	Status       string `json:"status"`
+	HealthState  string `json:"health_state"`
+	HealthReason string `json:"health_reason"`
+	Source       string `json:"source"`
+}
+
+// auditTargetListResponse is the envelope returned by GET audit/target/list.
+type auditTargetListResponse struct {
+	AuditEndpoints []AuditTarget `json:"audit_endpoints"`
+}
+
+// auditTargetSetBody is the request body for PUT audit/target/{type}/{name}.
+type auditTargetSetBody struct {
+	KeyValues []AuditTargetKeyValue `json:"key_values"`
+}
+
+// ListAuditTargets lists all configured audit-log targets.
+func (c *RustfsAdmin) ListAuditTargets() ([]AuditTarget, error) {
+	reqData := RequestData{
+		Method:  "GET",
+		RelPath: "audit/target/list",
+	}
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	resp, err := c.doRequest(ctx, reqData)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+
+	var out auditTargetListResponse
+	if err := json.NewDecoder(resp.Body).Decode(&out); err != nil {
+		return nil, err
+	}
+	return out.AuditEndpoints, nil
+}
+
+// SetAuditTarget adds or edits an audit target, sending keyValues as the
+// target configuration. The server validates the keys against the target type
+// and automatically enables the target.
+func (c *RustfsAdmin) SetAuditTarget(targetType, targetName string, keyValues []AuditTargetKeyValue) error {
+	body := auditTargetSetBody{KeyValues: keyValues}
+	//#nosec G117 — the marshaled body is the target's own configuration and
+	// may contain an auth token, which is expected to be transmitted to the
+	// admin API; it is never logged by this client.
+	bytes, err := json.Marshal(body)
+	if err != nil {
+		return err
+	}
+	reqData := RequestData{
+		Method:  "PUT",
+		RelPath: fmt.Sprintf("audit/target/%s/%s", targetType, targetName),
+		Content: bytes,
+	}
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	resp, err := c.doRequest(ctx, reqData)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+	return nil
+}
+
+// ResetAuditTarget removes an audit target, reverting it to the server default
+// (the admin API exposes no plain delete for targets).
+func (c *RustfsAdmin) ResetAuditTarget(targetType, targetName string) error {
+	reqData := RequestData{
+		Method:  "DELETE",
+		RelPath: fmt.Sprintf("audit/target/%s/%s/reset", targetType, targetName),
+	}
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	resp, err := c.doRequest(ctx, reqData)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+	return nil
+}

--- a/pkg/rustfs/audit_target_test.go
+++ b/pkg/rustfs/audit_target_test.go
@@ -1,0 +1,110 @@
+package rustfs
+
+import (
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+func newAuditTargetTestServer(t *testing.T, handler http.HandlerFunc) *RustfsAdmin {
+	t.Helper()
+	srv := httptest.NewServer(handler)
+	t.Cleanup(srv.Close)
+	c := New(&RustfsAdminConfig{
+		AccessKey:    "admin",
+		AccessSecret: "secret",
+		Endpoint:     strings.TrimPrefix(srv.URL, "http://"),
+	})
+	return &c
+}
+
+func TestListAuditTargets(t *testing.T) {
+	client := newAuditTargetTestServer(t, func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodGet {
+			t.Errorf("expected GET, got %s", r.Method)
+		}
+		if r.URL.Path != "/rustfs/admin/v3/audit/target/list" {
+			t.Errorf("wrong path: %s", r.URL.Path)
+		}
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"audit_endpoints":[{"account_id":"audit","service":"webhook","status":"offline","health_state":"offline","health_reason":"not_loaded_in_runtime","source":"config"}]}`))
+	})
+	targets, err := client.ListAuditTargets()
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(targets) != 1 {
+		t.Fatalf("expected 1 target, got %d", len(targets))
+	}
+	target := targets[0]
+	if target.AccountID != "audit" || target.Service != "webhook" {
+		t.Errorf("wrong target: %+v", target)
+	}
+	if target.Source != "config" || target.Status != "offline" {
+		t.Errorf("wrong target metadata: %+v", target)
+	}
+}
+
+func TestSetAuditTarget(t *testing.T) {
+	client := newAuditTargetTestServer(t, func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPut {
+			t.Errorf("expected PUT, got %s", r.Method)
+		}
+		if r.URL.Path != "/rustfs/admin/v3/audit/target/audit_webhook/audit" {
+			t.Errorf("wrong path: %s", r.URL.Path)
+		}
+		body, _ := io.ReadAll(r.Body)
+		var payload auditTargetSetBody
+		if err := json.Unmarshal(body, &payload); err != nil {
+			t.Errorf("invalid body: %v", err)
+		}
+		if len(payload.KeyValues) != 3 {
+			t.Fatalf("expected 3 key values, got %d", len(payload.KeyValues))
+		}
+		kv := map[string]string{}
+		for _, item := range payload.KeyValues {
+			kv[item.Key] = item.Value
+		}
+		if kv["endpoint"] != "https://hooks.example/webhook" || kv["auth_token"] != "s3cr3t" || kv["comment"] != "audit logs" {
+			t.Errorf("wrong body: %s", string(body))
+		}
+		w.WriteHeader(http.StatusOK)
+	})
+	err := client.SetAuditTarget("audit_webhook", "audit", []AuditTargetKeyValue{
+		{Key: "endpoint", Value: "https://hooks.example/webhook"},
+		{Key: "auth_token", Value: "s3cr3t"},
+		{Key: "comment", Value: "audit logs"},
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestResetAuditTarget(t *testing.T) {
+	client := newAuditTargetTestServer(t, func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodDelete {
+			t.Errorf("expected DELETE, got %s", r.Method)
+		}
+		if r.URL.Path != "/rustfs/admin/v3/audit/target/audit_webhook/audit/reset" {
+			t.Errorf("wrong path: %s", r.URL.Path)
+		}
+		w.WriteHeader(http.StatusOK)
+	})
+	if err := client.ResetAuditTarget("audit_webhook", "audit"); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestSetAuditTargetError(t *testing.T) {
+	client := newAuditTargetTestServer(t, func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusBadRequest)
+		_, _ = w.Write([]byte(`{"Code":"InvalidArgument","Message":"endpoint is required"}`))
+	})
+	err := client.SetAuditTarget("audit_webhook", "audit", []AuditTargetKeyValue{{Key: "comment", Value: "x"}})
+	if err == nil {
+		t.Fatal("expected an error for a rejected request")
+	}
+}

--- a/provider/provider.go
+++ b/provider/provider.go
@@ -137,6 +137,7 @@ func (p *RustfsProvider) Resources(ctx context.Context) []func() resource.Resour
 		NewBucketReplicationResource,
 		NewBucketEncryptionResource,
 		NewBucketVersioningResource,
+		NewAuditTargetRessource,
 	}
 }
 

--- a/provider/rustfs_audit_target_ressource.go
+++ b/provider/rustfs_audit_target_ressource.go
@@ -1,0 +1,349 @@
+package provider
+
+import (
+	"context"
+	"fmt"
+	"strconv"
+	"strings"
+
+	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
+	"github.com/hashicorp/terraform-plugin-framework/path"
+	"github.com/hashicorp/terraform-plugin-framework/resource"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/booldefault"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringdefault"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/hashicorp/terraform-plugin-log/tflog"
+	"github.com/weinmann-emt/terraform-provider-rustfs/pkg/rustfs"
+)
+
+// Ensure the implementation satisfies the expected interfaces.
+var (
+	_ resource.Resource                = &auditTargetRessource{}
+	_ resource.ResourceWithImportState = &auditTargetRessource{}
+)
+
+// NewAuditTargetRessource is a helper function to simplify the provider implementation.
+func NewAuditTargetRessource() resource.Resource {
+	return &auditTargetRessource{}
+}
+
+// auditTargetRessource is the resource implementation.
+type auditTargetRessource struct {
+	client *AllClient
+}
+
+type auditTargetRessourceModel struct {
+	TargetType    types.String `tfsdk:"target_type"`
+	TargetName    types.String `tfsdk:"target_name"`
+	Endpoint      types.String `tfsdk:"endpoint"`
+	AuthToken     types.String `tfsdk:"auth_token"`
+	Comment       types.String `tfsdk:"comment"`
+	QueueLimit    types.Int64  `tfsdk:"queue_limit"`
+	QueueDir      types.String `tfsdk:"queue_dir"`
+	ClientCert    types.String `tfsdk:"client_cert"`
+	ClientKey     types.String `tfsdk:"client_key"`
+	ClientCA      types.String `tfsdk:"client_ca"`
+	SkipTLSVerify types.Bool   `tfsdk:"skip_tls_verify"`
+	HealthState   types.String `tfsdk:"health_state"`
+	HealthReason  types.String `tfsdk:"health_reason"`
+	Status        types.String `tfsdk:"status"`
+}
+
+// Metadata returns the resource type name.
+func (r *auditTargetRessource) Metadata(_ context.Context, req resource.MetadataRequest, resp *resource.MetadataResponse) {
+	resp.TypeName = req.ProviderTypeName + "_audit_target"
+}
+
+// Schema defines the schema for the resource.
+func (r *auditTargetRessource) Schema(_ context.Context, _ resource.SchemaRequest, resp *resource.SchemaResponse) {
+	resp.Schema = schema.Schema{
+		Description:         "Manage RustFS audit-log webhook/HTTP targets",
+		MarkdownDescription: "Manage RustFS audit-log webhook/HTTP targets",
+		Attributes: map[string]schema.Attribute{
+			"target_type": schema.StringAttribute{
+				Optional:    true,
+				Computed:    true,
+				Default:     stringdefault.StaticString("audit_webhook"),
+				Description: "Audit target subsystem. Defaults to audit_webhook.",
+				Validators: []validator.String{stringvalidator.OneOf(
+					"audit_webhook",
+					"audit_kafka",
+					"audit_amqp",
+					"audit_mqtt",
+					"audit_mysql",
+					"audit_nats",
+					"audit_postgres",
+					"audit_pulsar",
+					"audit_redis",
+				)},
+			},
+			"target_name": schema.StringAttribute{
+				Required:      true,
+				Description:   "Name of the audit target. Changing this forces recreation.",
+				PlanModifiers: []planmodifier.String{stringplanmodifier.RequiresReplace()},
+			},
+			"endpoint": schema.StringAttribute{
+				Optional:    true,
+				Description: "Endpoint URL the audit target posts to (webhook).",
+			},
+			"auth_token": schema.StringAttribute{
+				Optional:    true,
+				Sensitive:   true,
+				Description: "Optional bearer token for the audit target (webhook). Not refreshed from the server on read.",
+			},
+			"comment": schema.StringAttribute{
+				Optional:    true,
+				Description: "Optional comment describing the audit target.",
+			},
+			"queue_limit": schema.Int64Attribute{
+				Optional:    true,
+				Description: "Optional in-memory queue limit for the audit target.",
+			},
+			"queue_dir": schema.StringAttribute{
+				Optional:    true,
+				Description: "Optional absolute path of the on-disk queue directory for the audit target.",
+			},
+			"client_cert": schema.StringAttribute{
+				Optional:    true,
+				Sensitive:   true,
+				Description: "Optional client certificate for mTLS to the audit target.",
+			},
+			"client_key": schema.StringAttribute{
+				Optional:    true,
+				Sensitive:   true,
+				Description: "Optional client private key for mTLS to the audit target.",
+			},
+			"client_ca": schema.StringAttribute{
+				Optional:    true,
+				Sensitive:   true,
+				Description: "Optional CA certificate used to verify the audit target.",
+			},
+			"skip_tls_verify": schema.BoolAttribute{
+				Optional:    true,
+				Computed:    true,
+				Default:     booldefault.StaticBool(false),
+				Description: "Skip TLS certificate verification for the audit target.",
+			},
+			"health_state": schema.StringAttribute{
+				Computed:    true,
+				Description: "Runtime health state of the audit target (offline/online/...).",
+			},
+			"health_reason": schema.StringAttribute{
+				Computed:    true,
+				Description: "Runtime health reason for the audit target.",
+			},
+			"status": schema.StringAttribute{
+				Computed:    true,
+				Description: "Runtime status of the audit target.",
+			},
+		},
+	}
+}
+
+func (r *auditTargetRessource) Configure(_ context.Context, req resource.ConfigureRequest, resp *resource.ConfigureResponse) {
+	if req.ProviderData == nil {
+		return
+	}
+	client, ok := req.ProviderData.(*AllClient)
+	if !ok {
+		resp.Diagnostics.AddError(
+			"Unexpected Resource Configure Type",
+			fmt.Sprintf("Expected *AllClient, got: %T. Please report this issue to the provider developers.", req.ProviderData),
+		)
+		return
+	}
+	r.client = client
+}
+
+// auditTargetKeyValues builds the key/value config body from the resource model,
+// including only the fields the user has actually set.
+func (r *auditTargetRessource) auditTargetKeyValues(plan *auditTargetRessourceModel) []rustfs.AuditTargetKeyValue {
+	var kvs []rustfs.AuditTargetKeyValue
+	add := func(key string, value string) {
+		if value != "" {
+			kvs = append(kvs, rustfs.AuditTargetKeyValue{Key: key, Value: value})
+		}
+	}
+	add("endpoint", plan.Endpoint.ValueString())
+	add("auth_token", plan.AuthToken.ValueString())
+	add("comment", plan.Comment.ValueString())
+	add("queue_dir", plan.QueueDir.ValueString())
+	add("client_cert", plan.ClientCert.ValueString())
+	add("client_key", plan.ClientKey.ValueString())
+	add("client_ca", plan.ClientCA.ValueString())
+	if !plan.QueueLimit.IsNull() && !plan.QueueLimit.IsUnknown() {
+		kvs = append(kvs, rustfs.AuditTargetKeyValue{Key: "queue_limit", Value: strconv.FormatInt(plan.QueueLimit.ValueInt64(), 10)})
+	}
+	if !plan.SkipTLSVerify.IsNull() && !plan.SkipTLSVerify.IsUnknown() {
+		kvs = append(kvs, rustfs.AuditTargetKeyValue{Key: "skip_tls_verify", Value: strconv.FormatBool(plan.SkipTLSVerify.ValueBool())})
+	}
+	return kvs
+}
+
+// serviceForType maps an audit target_type to the service reported by the list
+// endpoint (audit_webhook -> webhook, audit_kafka -> kafka, ...).
+func serviceForType(targetType string) string {
+	return strings.TrimPrefix(targetType, "audit_")
+}
+
+// Create adds the audit target and sets the initial Terraform state.
+func (r *auditTargetRessource) Create(ctx context.Context, req resource.CreateRequest, resp *resource.CreateResponse) {
+	var plan auditTargetRessourceModel
+	resp.Diagnostics.Append(req.Plan.Get(ctx, &plan)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	if err := r.client.RustClient.SetAuditTarget(
+		plan.TargetType.ValueString(),
+		plan.TargetName.ValueString(),
+		r.auditTargetKeyValues(&plan),
+	); err != nil {
+		resp.Diagnostics.AddError(
+			"Error creating audit target",
+			"Could not create audit target, unexpected error: "+err.Error(),
+		)
+		return
+	}
+	tflog.Trace(ctx, "created an audit target")
+	if err := r.refreshHealth(&plan); err != nil {
+		resp.Diagnostics.AddError(
+			"Error reading audit target",
+			"Could not read audit target after create, unexpected error: "+err.Error(),
+		)
+		return
+	}
+	resp.Diagnostics.Append(resp.State.Set(ctx, &plan)...)
+}
+
+// refreshHealth lists the audit targets and populates the computed health
+// metadata on the model when the target is present.
+func (r *auditTargetRessource) refreshHealth(model *auditTargetRessourceModel) error {
+	targets, err := r.client.RustClient.ListAuditTargets()
+	if err != nil {
+		return err
+	}
+
+	key := model.TargetName.ValueString()
+	service := serviceForType(model.TargetType.ValueString())
+	for i := range targets {
+		t := &targets[i]
+		if t.AccountID == key && (service == "" || t.Service == service) {
+			model.Status = types.StringValue(t.Status)
+			model.HealthState = types.StringValue(t.HealthState)
+			model.HealthReason = types.StringValue(t.HealthReason)
+			return nil
+		}
+	}
+	return fmt.Errorf("audit target %s not found in list", key)
+}
+
+// Read refreshes the Terraform state with the latest data. The admin list
+// endpoint does not echo the target configuration (endpoint, auth token, ...),
+// only identity and health metadata, so the config fields are preserved from
+// the prior state and only the health/computed metadata is refreshed.
+func (r *auditTargetRessource) Read(ctx context.Context, req resource.ReadRequest, resp *resource.ReadResponse) {
+	var state auditTargetRessourceModel
+	resp.Diagnostics.Append(req.State.Get(ctx, &state)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	targets, err := r.client.RustClient.ListAuditTargets()
+	if err != nil {
+		resp.Diagnostics.AddError(
+			"Error listing audit targets",
+			"Could not list audit targets, unexpected error: "+err.Error(),
+		)
+		return
+	}
+
+	key := state.TargetName.ValueString()
+	service := serviceForType(state.TargetType.ValueString())
+	var found *rustfs.AuditTarget
+	for i := range targets {
+		t := &targets[i]
+		if t.AccountID == key && (service == "" || t.Service == service) {
+			found = t
+			break
+		}
+	}
+	if found == nil {
+		resp.State.RemoveResource(ctx)
+		return
+	}
+
+	state.Status = types.StringValue(found.Status)
+	state.HealthState = types.StringValue(found.HealthState)
+	state.HealthReason = types.StringValue(found.HealthReason)
+	// endpoint, auth_token, comment and the other config fields are preserved
+	// from state; the list response is not trusted to echo them back.
+	resp.Diagnostics.Append(resp.State.Set(ctx, &state)...)
+}
+
+// Update edits the audit target and updates the Terraform state on success.
+func (r *auditTargetRessource) Update(ctx context.Context, req resource.UpdateRequest, resp *resource.UpdateResponse) {
+	var plan auditTargetRessourceModel
+	resp.Diagnostics.Append(req.Plan.Get(ctx, &plan)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	if err := r.client.RustClient.SetAuditTarget(
+		plan.TargetType.ValueString(),
+		plan.TargetName.ValueString(),
+		r.auditTargetKeyValues(&plan),
+	); err != nil {
+		resp.Diagnostics.AddError(
+			"Error updating audit target",
+			"Could not update audit target, unexpected error: "+err.Error(),
+		)
+		return
+	}
+	if err := r.refreshHealth(&plan); err != nil {
+		resp.Diagnostics.AddError(
+			"Error reading audit target",
+			"Could not read audit target after update, unexpected error: "+err.Error(),
+		)
+		return
+	}
+	resp.Diagnostics.Append(resp.State.Set(ctx, &plan)...)
+}
+
+// Delete resets the audit target to its default configuration and removes the
+// Terraform state. The admin API exposes no plain delete for targets, so
+// destroy goes through the reset endpoint.
+func (r *auditTargetRessource) Delete(ctx context.Context, req resource.DeleteRequest, resp *resource.DeleteResponse) {
+	var state auditTargetRessourceModel
+	resp.Diagnostics.Append(req.State.Get(ctx, &state)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	if err := r.client.RustClient.ResetAuditTarget(
+		state.TargetType.ValueString(),
+		state.TargetName.ValueString(),
+	); err != nil {
+		resp.Diagnostics.AddError(
+			"Error resetting audit target",
+			"Could not reset audit target, unexpected error: "+err.Error(),
+		)
+	}
+}
+
+func (r *auditTargetRessource) ImportState(ctx context.Context, req resource.ImportStateRequest, resp *resource.ImportStateResponse) {
+	parts := strings.Split(req.ID, "/")
+	if len(parts) != 2 {
+		resp.Diagnostics.AddError(
+			"Invalid import ID",
+			"Expected the import ID to be <target_type>/<target_name>",
+		)
+		return
+	}
+	resp.Diagnostics.Append(resp.State.SetAttribute(ctx, path.Root("target_type"), parts[0])...)
+	resp.Diagnostics.Append(resp.State.SetAttribute(ctx, path.Root("target_name"), parts[1])...)
+}

--- a/provider/rustfs_audit_target_ressource_test.go
+++ b/provider/rustfs_audit_target_ressource_test.go
@@ -1,0 +1,137 @@
+package provider
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-testing/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/terraform"
+)
+
+const auditTargetResourceName = "rustfs_audit_target.test"
+
+func TestAccAuditTargetResource(t *testing.T) {
+	name := fmt.Sprintf("tf-audit-%d", acctest.RandInt())
+	endpoint := fmt.Sprintf("https://hooks.example.com/webhook/%s", name)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { testAccAuditTargetPreCheck(t) },
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		CheckDestroy:             testAccCheckAuditTargetDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAuditTargetConfig(name, endpoint),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckAuditTargetExists(name),
+					resource.TestCheckResourceAttr(auditTargetResourceName, "target_type", "audit_webhook"),
+					resource.TestCheckResourceAttr(auditTargetResourceName, "target_name", name),
+					resource.TestCheckResourceAttr(auditTargetResourceName, "endpoint", endpoint),
+					resource.TestCheckResourceAttr(auditTargetResourceName, "auth_token", "superSecret"),
+					resource.TestCheckResourceAttr(auditTargetResourceName, "comment", "managed by terraform"),
+					resource.TestCheckResourceAttrSet(auditTargetResourceName, "health_state"),
+				),
+			},
+			{
+				Config: testAccAuditTargetConfigUpdated(name, endpoint),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckAuditTargetExists(name),
+					resource.TestCheckResourceAttr(auditTargetResourceName, "comment", "updated by terraform"),
+					resource.TestCheckResourceAttrSet(auditTargetResourceName, "health_state"),
+				),
+			},
+			{
+				ResourceName:      auditTargetResourceName,
+				ImportState:       true,
+				ImportStateId:     "audit_webhook/" + name,
+				ImportStateVerify: true,
+				// The admin list endpoint does not echo config values, so these
+				// attributes cannot be verified after import.
+				ImportStateVerifyIdentifierAttribute: "target_name",
+				ImportStateVerifyIgnore:              []string{"endpoint", "auth_token", "comment", "queue_limit", "queue_dir", "client_cert", "client_key", "client_ca", "skip_tls_verify", "health_state", "health_reason", "status"},
+			},
+		},
+	})
+}
+
+// testAccAuditTargetPreCheck verifies the environment and that the running
+// RustFS has the audit module enabled (the admin API rejects target management
+// otherwise). The test skips gracefully when the audit module is disabled.
+func testAccAuditTargetPreCheck(t *testing.T) {
+	testAccPreCheck(t)
+
+	client := testAccRustClient()
+	if _, err := client.ListAuditTargets(); err != nil {
+		t.Skipf("audit target management is not available on the running RustFS (audit module disabled?), skipping: %v", err)
+	}
+}
+
+func testAccAuditTargetConfig(name, endpoint string) string {
+	return testAccProviderConfig() + fmt.Sprintf(`
+resource "rustfs_audit_target" "test" {
+  target_type = "audit_webhook"
+  target_name = "%s"
+  endpoint    = "%s"
+  auth_token  = "superSecret"
+  comment     = "managed by terraform"
+}
+`, name, endpoint)
+}
+
+func testAccAuditTargetConfigUpdated(name, endpoint string) string {
+	return testAccProviderConfig() + fmt.Sprintf(`
+resource "rustfs_audit_target" "test" {
+  target_type = "audit_webhook"
+  target_name = "%s"
+  endpoint    = "%s"
+  auth_token  = "superSecret"
+  comment     = "updated by terraform"
+}
+`, name, endpoint)
+}
+
+func testAccCheckAuditTargetExists(name string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[auditTargetResourceName]
+		if !ok {
+			return fmt.Errorf("not found: %s", auditTargetResourceName)
+		}
+		targetName := rs.Primary.Attributes["target_name"]
+		if targetName == "" {
+			return fmt.Errorf("no target_name set")
+		}
+
+		client := testAccRustClient()
+		targets, err := client.ListAuditTargets()
+		if err != nil {
+			return err
+		}
+		for _, target := range targets {
+			if target.AccountID == name && target.Service == "webhook" {
+				return nil
+			}
+		}
+		return fmt.Errorf("audit target %s not found in list", name)
+	}
+}
+
+func testAccCheckAuditTargetDestroy(s *terraform.State) error {
+	client := testAccRustClient()
+	targets, err := client.ListAuditTargets()
+	if err != nil {
+		return err
+	}
+	for _, rs := range s.RootModule().Resources {
+		if rs.Type != "rustfs_audit_target" {
+			continue
+		}
+		name := rs.Primary.Attributes["target_name"]
+		for _, target := range targets {
+			if strings.EqualFold(target.AccountID, name) {
+				return fmt.Errorf("audit target %s still exists", name)
+			}
+		}
+	}
+	return nil
+}

--- a/provider/rustfs_audit_target_ressource_test.go
+++ b/provider/rustfs_audit_target_ressource_test.go
@@ -8,6 +8,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-testing/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
+	"github.com/weinmann-emt/terraform-provider-rustfs/pkg/rustfs"
 )
 
 const auditTargetResourceName = "rustfs_audit_target.test"
@@ -57,13 +58,27 @@ func TestAccAuditTargetResource(t *testing.T) {
 
 // testAccAuditTargetPreCheck verifies the environment and that the running
 // RustFS has the audit module enabled (the admin API rejects target management
-// otherwise). The test skips gracefully when the audit module is disabled.
+// otherwise). The list endpoint succeeds even when the module is disabled, so
+// the check probes an actual create and skips when the server reports the
+// audit module is disabled.
 func testAccAuditTargetPreCheck(t *testing.T) {
 	testAccPreCheck(t)
 
 	client := testAccRustClient()
-	if _, err := client.ListAuditTargets(); err != nil {
-		t.Skipf("audit target management is not available on the running RustFS (audit module disabled?), skipping: %v", err)
+	probe := fmt.Sprintf("tf-audit-probe-%d", acctest.RandInt())
+	probeConfig := []rustfs.AuditTargetKeyValue{
+		{Key: "endpoint", Value: "https://hooks.example.com/webhook/" + probe},
+	}
+	err := client.SetAuditTarget("audit_webhook", probe, probeConfig)
+	if err != nil {
+		if strings.Contains(err.Error(), "audit module is disabled") {
+			t.Skipf("audit module is disabled on the running RustFS; skipping: %v", err)
+		}
+		t.Fatalf("audit target management is not available on the running RustFS, skipping: %v", err)
+	}
+	// Clean up the probe target so it does not linger in the server config.
+	if err := client.ResetAuditTarget("audit_webhook", probe); err != nil {
+		t.Logf("could not clean up audit target probe %s: %v", probe, err)
 	}
 }
 


### PR DESCRIPTION
**Issue:** https://github.com/weinmann-emt/terraform-provider-rustfs/issues/120

Add a `rustfs_audit_target` resource to manage audit-log webhook/HTTP targets.

Closes #120

## Changes
- `pkg/rustfs/audit_target.go`: client for list/create/update/reset matching the verified contract.
- `provider/rustfs_audit_target_ressource.go` (config fields `endpoint`, `auth_token`, `comment`, ...; Sensitive auth; import as `target_type/target_name`), registered in `Resources()`.
- Unit (httptest) + acceptance tests; docs + example.

## Testing
- `go build`, `go vet`, gofmt clean; golangci-lint no new findings; gosec 0 issues.
- 4/4 httptest unit tests + acceptance (create → update → import → destroy) pass against a live RustFS.

## Note
Verified against RustFS source + live server: the PUT body is `{"key_values":[...]}`, `target_type` is `audit_webhook` (not `http`/`webhook`), and the list endpoint returns only identity/health metadata (no config/credentials) — so config fields are config-preserved and never server-refreshed. The acceptance test skips gracefully if the audit module is off.
